### PR TITLE
Make token limit bigger to avoid issues while parsing long regexp.

### DIFF
--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -26,7 +26,7 @@ class Grammar
 
     @repository = null
     @initialRule = null
-    @maxTokensPerLine = 100
+    @maxTokensPerLine = 10000
 
     @rawPatterns = patterns
     @rawRepository = repository


### PR DESCRIPTION
Maybe 10000 is such a big number, but it is big enough as a simple patch until long lines are handled better.
