### PR TITLE
Change the maxTokensPerLine default option to Infinity

### DIFF
--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -11,7 +11,7 @@ class GrammarRegistry
   Emitter.includeInto(this)
 
   constructor: (options={}) ->
-    @maxTokensPerLine = options.maxTokensPerLine ? 100
+    @maxTokensPerLine = options.maxTokensPerLine ? Infinity
     @grammars = []
     @grammarsByScopeName = {}
     @injectionGrammars = []


### PR DESCRIPTION
Atom/Highlights use Infinity for maxTokensPerLine, but It appears some Highlighters or grammar use the default option (I have a document in latex that is not highlighted properly). So I think we can set the default to Infinity.
