### PR TITLE
Export "Grammar" class

### DIFF
--- a/src/first-mate.coffee
+++ b/src/first-mate.coffee
@@ -1,3 +1,4 @@
 module.exports =
   ScopeSelector: require './scope-selector'
   GrammarRegistry: require './grammar-registry'
+  Grammar: require './grammar'


### PR DESCRIPTION
Allows other packages to inherit from `Grammar` in order to programmatically define language grammars.

Use case: https://github.com/p-e-w/language-javascript-semantic
Previous discussion: https://github.com/atom/atom/issues/2548
