### PR TITLE
File glob matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "oniguruma": "^3",
     "emissary": "^1",
     "fs-plus": "^2",
-    "season": "^1"
+    "season": "^1",
+    "minimatch": "^1"
   },
   "devDependencies": {
     "jasmine-focused": "^1",

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -809,6 +809,26 @@ describe "Grammar tokenization", ->
       expect(tokens[0].value).toEqual 'test'
       expect(tokens[0].scopes).toEqual ['source.loops']
 
+  describe '::isGlob', ->
+    beforeEach ->
+      grammar = registry.grammarForScopeName("text.html.basic")
+
+    it 'returns true when a string is a glob', ->
+      expect(grammar.isGlob("*.html")).toBeTruthy
+
+    it 'returns fals when a string is not a glob', ->
+      expect(grammar.isGlob("html")).toBeFalsy
+
+  describe '::scoreFromGlob', ->
+    beforeEach ->
+      grammar = registry.grammarForScopeName("text.html.basic")
+
+    it 'returns -1 for no match', ->
+      expect(grammar.scoreFromGlob("foo.html", "*.foo")).toBe -1
+
+    it 'returns the length of the match when matched', ->
+      expect(grammar.scoreFromGlob("foo.html", "*.html")).toBe 8
+
   describe '::getScore', ->
     beforeEach ->
       grammar = registry.grammarForScopeName("text.html.basic")
@@ -826,3 +846,8 @@ describe "Grammar tokenization", ->
       registry.setGrammarOverrideForPath("foo.foo", "text.html.basic")
 
       expect(grammar.getScore("foo.foo", null)).toBe 9
+
+    it 'returns the length of the match when a file glob matches', ->
+      grammar.fileTypes = grammar.fileTypes.concat ["*.foo"]
+
+      expect(grammar.getScore("foo.foo", null)).toBe 7

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -816,7 +816,7 @@ describe "Grammar tokenization", ->
     it 'returns true when a string is a glob', ->
       expect(grammar.isGlob("*.html")).toBeTruthy
 
-    it 'returns fals when a string is not a glob', ->
+    it 'returns false when a string is not a glob', ->
       expect(grammar.isGlob("html")).toBeFalsy
 
   describe '::scoreFromGlob', ->
@@ -826,8 +826,8 @@ describe "Grammar tokenization", ->
     it 'returns -1 for no match', ->
       expect(grammar.scoreFromGlob("foo.html", "*.foo")).toBe -1
 
-    it 'returns the length of the match when matched', ->
-      expect(grammar.scoreFromGlob("foo.html", "*.html")).toBe 8
+    it 'returns the length of the pattern without wildcards when matched', ->
+      expect(grammar.scoreFromGlob("foo.html", "*.html")).toBe 5
 
   describe '::getScore', ->
     beforeEach ->
@@ -836,7 +836,7 @@ describe "Grammar tokenization", ->
     it 'returns -1 for no match', ->
       expect(grammar.getScore("foo.foo", null)).toBe -1
 
-    it 'returns the length of the match when the filename matches', ->
+    it 'returns the length of the match when the extension matches', ->
       expect(grammar.getScore("foo.html", null)).toBe 4
 
     it 'returns one more than the length of the filename when the contents match', ->
@@ -847,7 +847,7 @@ describe "Grammar tokenization", ->
 
       expect(grammar.getScore("foo.foo", null)).toBe 9
 
-    it 'returns the length of the match when a file glob matches', ->
+    it 'returns the length of the pattern without wildcards when a file glob matches', ->
       grammar.fileTypes = grammar.fileTypes.concat ["*.foo"]
 
-      expect(grammar.getScore("foo.foo", null)).toBe 7
+      expect(grammar.getScore("foo.foo", null)).toBe 4

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -808,3 +808,21 @@ describe "Grammar tokenization", ->
       expect(tokens.length).toBe 1
       expect(tokens[0].value).toEqual 'test'
       expect(tokens[0].scopes).toEqual ['source.loops']
+
+  describe '::getScore', ->
+    beforeEach ->
+      grammar = registry.grammarForScopeName("text.html.basic")
+
+    it 'returns -1 for no match', ->
+      expect(grammar.getScore("foo.foo", null)).toBe -1
+
+    it 'returns the length of the match when the filename matches', ->
+      expect(grammar.getScore("foo.html", null)).toBe 4
+
+    it 'returns one more than the length of the filename when the contents match', ->
+      expect(grammar.getScore("foo.html", "<html>")).toBe 9
+
+    it 'returns two more than the length of the filename when there is an override', ->
+      registry.setGrammarOverrideForPath("foo.foo", "text.html.basic")
+
+      expect(grammar.getScore("foo.foo", null)).toBe 9

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -220,12 +220,7 @@ class Grammar
     /\*|\?|\{/.test(fileType)
 
   scoreFromGlob: (filePath, fileType) ->
-    re = minimatch.makeRe(fileType)
-    match = re.exec(filePath)
-    if match
-      match[0].length
-    else
-      -1
+    if minimatch(filePath, fileType) then fileType.replace(/\*|\?/, '').length else -1
 
   createToken: (value, scopes) -> @registry.createToken(value, scopes)
 

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -206,12 +206,26 @@ class Grammar
     pathComponents = filePath.toLowerCase().split(pathSplitRegex)
     pathScore = -1
     for fileType in @fileTypes
-      fileTypeComponents = fileType.toLowerCase().split(pathSplitRegex)
-      pathSuffix = pathComponents[-fileTypeComponents.length..-1]
-      if _.isEqual(pathSuffix, fileTypeComponents)
-        pathScore = Math.max(pathScore, fileType.length)
+      if @isGlob(fileType)
+        pathScore = Math.max(pathScore, @scoreFromGlob(filePath, fileType))
+      else
+        fileTypeComponents = fileType.toLowerCase().split(pathSplitRegex)
+        pathSuffix = pathComponents[-fileTypeComponents.length..-1]
+        if _.isEqual(pathSuffix, fileTypeComponents)
+          pathScore = Math.max(pathScore, fileType.length)
 
     pathScore
+
+  isGlob: (fileType) ->
+    /\*|\?|\{/.test(fileType)
+
+  scoreFromGlob: (filePath, fileType) ->
+    re = minimatch.makeRe(fileType)
+    match = re.exec(filePath)
+    if match
+      match[0].length
+    else
+      -1
 
   createToken: (value, scopes) -> @registry.createToken(value, scopes)
 

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -2,6 +2,7 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
+minimatch = require 'minimatch'
 {OnigRegExp} = require 'oniguruma'
 {Emitter} = require 'emissary'
 


### PR DESCRIPTION
So you'll notice because most people will tend to write `*.foo` when using a glob instead of `foo` just referring to the extension that the equivalent glob will generally win. And if it doesn't win, then it is equal length anyway (like `Gruntfile` as both the extension and the glob). There may be more edge cases that I'm not thinking about right now ... but this was my general idea.

Applies to atom/first-mate#17