### PR TITLE
Correct punctuation typo

### DIFF
--- a/spec/fixtures/scss.json
+++ b/spec/fixtures/scss.json
@@ -1120,7 +1120,7 @@
     "selector_id": {
       "captures": {
         "1": {
-          "name": "punctuationctuation.definition.entity.css"
+          "name": "punctuation.definition.entity.css"
         }
       },
       "match": "(#)[a-zA-Z][a-zA-Z0-9_-]*",


### PR DESCRIPTION
Related to https://github.com/atom/language-sass/issues/28 and https://github.com/atom/language-sass/commit/eb2c447e45141f5efce3cd0d26d65286a027351d

cc @kevinsawicki 
