### PR TITLE
:bug: Fix wrong scopes applied to lines following a very long line.

### DIFF
--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -467,9 +467,9 @@ describe "Grammar tokenization", ->
         grammar.tokenizeLine('')
         spyOn(grammar, 'getMaxTokensPerLine').andCallFake -> 5
         originalRuleStack = [grammar.initialRule, grammar.initialRule, grammar.initialRule]
-        {tokens, ruleStack} = grammar.tokenizeLine("one(two(three(four(five(_param_)))))", originalRuleStack)
-        expect(tokens.length).toBe 5
-        expect(tokens[4].value).toBe "three(four(five(_param_)))))"
+        {tokens, ruleStack} = grammar.tokenizeLine("var x = /[a-z]/;", originalRuleStack)
+        expect(tokens.length).toBe 6
+        expect(tokens[5].value).toBe "[a-z]/;"
         expect(ruleStack).toEqual originalRuleStack
 
     describe "when a grammar has a capture with patterns", ->

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -107,7 +107,7 @@ class Grammar
       ruleStack = ruleStack.slice()
     else
       ruleStack = [@getInitialRule()]
-    originalRuleStack = ruleStack
+    originalRuleStack = ruleStack.slice()
 
     tokens = []
     position = 0


### PR DESCRIPTION
Make sure the rule stack is copied, so that modifying it does not modify the
original. This was causing the stack to be 'restored' to the wrong state when
the max tokens per line limit was reached and there were no initial rules.

See https://github.com/atom/atom/issues/1667#issuecomment-69776121