### PR TITLE
Represent parse results as an array of integers instead of token objects

### DIFF
--- a/benchmark/benchmark.coffee
+++ b/benchmark/benchmark.coffee
@@ -10,9 +10,10 @@ cssGrammar.maxTokensPerLine = Infinity
 
 tokenize = (grammar, content, lineCount) ->
   start = Date.now()
-  tokens = grammar.tokenizeLines(content)
+  {tags} = grammar.tokenizeLines(content)
   duration = Date.now() - start
-  tokenCount = tokens.reduce ((count, line) -> count + line.length), 0
+  tokenCount = 0
+  tokenCount++ for tag in tags when tag >= 0
   tokensPerMillisecond = Math.round(tokenCount / duration)
   console.log "Generated #{tokenCount} tokens for #{lineCount} lines in #{duration}ms (#{tokensPerMillisecond} tokens/ms)"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "grunt test",
     "prepublish": "grunt prepublish",
-    "benchmark": "node_modules/.bin/coffee --nodejs --harmony_collections benchmark/benchmark.coffee"
+    "benchmark": "node_modules/.bin/coffee benchmark/benchmark.coffee"
   },
   "repository": {
     "type": "git",

--- a/spec/grammar-registry-spec.coffee
+++ b/spec/grammar-registry-spec.coffee
@@ -95,6 +95,6 @@ describe "GrammarRegistry", ->
       grammar = registry.selectGrammar('test.json')
       expect(grammar.maxTokensPerLine).toBe 2
 
-      {content} = grammar.tokenizeLine("{ }")
-      tokens = registry.decodeContent(content)
+      {line, tags} = grammar.tokenizeLine("{ }")
+      tokens = registry.decodeContent(line, tags)
       expect(tokens.length).toBe 2

--- a/spec/grammar-registry-spec.coffee
+++ b/spec/grammar-registry-spec.coffee
@@ -95,5 +95,6 @@ describe "GrammarRegistry", ->
       grammar = registry.selectGrammar('test.json')
       expect(grammar.maxTokensPerLine).toBe 2
 
-      {tokens} = grammar.tokenizeLine("{ }")
+      {content} = grammar.tokenizeLine("{ }")
+      tokens = registry.decodeContent(content)
       expect(tokens.length).toBe 2

--- a/spec/grammar-registry-spec.coffee
+++ b/spec/grammar-registry-spec.coffee
@@ -96,5 +96,5 @@ describe "GrammarRegistry", ->
       expect(grammar.maxTokensPerLine).toBe 2
 
       {line, tags} = grammar.tokenizeLine("{ }")
-      tokens = registry.decodeContent(line, tags)
+      tokens = registry.decodeTokens(line, tags)
       expect(tokens.length).toBe 2

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -10,6 +10,8 @@ describe "Grammar tokenization", ->
   loadGrammarSync = (name) ->
     registry.loadGrammarSync(path.join(__dirname, 'fixtures', name))
 
+  decodeContent = (content, scopes = []) -> registry.decodeContent(content, scopes)
+
   beforeEach ->
     registry = new GrammarRegistry()
     loadGrammarSync('text.json')
@@ -27,7 +29,8 @@ describe "Grammar tokenization", ->
     it "tokenizes using the null grammar", ->
       emptyRegistry = new GrammarRegistry()
       grammar = emptyRegistry.selectGrammar('foo.js', '')
-      {tokens} = grammar.tokenizeLine('a = 1;')
+      {content} = grammar.tokenizeLine('a = 1;')
+      tokens = emptyRegistry.decodeContent(content)
       expect(tokens.length).toBe 1
       expect(tokens[0].value).toBe 'a = 1;'
       expect(tokens[0].scopes).toEqual ['text.plain.null-grammar']
@@ -36,7 +39,9 @@ describe "Grammar tokenization", ->
       registry = new GrammarRegistry()
       loadGrammarSync('hyperlink.json')
 
-      {tokens} = registry.nullGrammar.tokenizeLine('http://github.com')
+      grammar = registry.nullGrammar
+      {content} = grammar.tokenizeLine('http://github.com')
+      tokens = decodeContent(content)
       expect(tokens.length).toBe 1
       expect(tokens[0].value).toEqual 'http://github.com'
       expect(tokens[0].scopes).toEqual ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
@@ -47,7 +52,8 @@ describe "Grammar tokenization", ->
       expect(fs.isFileSync(grammar.path)).toBe true
       expect(grammar).not.toBeNull()
 
-      {tokens} = grammar.tokenizeLine('hello world!')
+      {content} = grammar.tokenizeLine('hello world!')
+      tokens = decodeContent(content)
       expect(tokens.length).toBe 4
 
       expect(tokens[0].value).toBe 'hello'
@@ -66,48 +72,50 @@ describe "Grammar tokenization", ->
     describe "when the entire line matches a single pattern with no capture groups", ->
       it "returns a single token with the correct scope", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine("return")
+        {content} = grammar.tokenizeLine("return")
 
-        expect(tokens.length).toBe 1
-        [token] = tokens
-        expect(token.scopes).toEqual ['source.coffee', 'keyword.control.coffee']
+        expect(decodeContent(content)).toEqual [
+          {value: 'return', scopes: ['source.coffee', 'keyword.control.coffee']}
+        ]
 
     describe "when the entire line matches a single pattern with capture groups", ->
       it "returns a single token with the correct scope", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine("new foo.bar.Baz")
-
-        expect(tokens.length).toBe 3
-        [newOperator, whitespace, className] = tokens
-        expect(newOperator).toEqual value: 'new', scopes: ['source.coffee', 'meta.class.instance.constructor', 'keyword.operator.new.coffee']
-        expect(whitespace).toEqual value: ' ', scopes: ['source.coffee', 'meta.class.instance.constructor']
-        expect(className).toEqual value: 'foo.bar.Baz', scopes: ['source.coffee', 'meta.class.instance.constructor', 'entity.name.type.instance.coffee']
+        {content} = grammar.tokenizeLine("new foo.bar.Baz")
+        expect(decodeContent(content)).toEqual [
+          {value: 'new', scopes: ['source.coffee', 'meta.class.instance.constructor', 'keyword.operator.new.coffee']}
+          {value: ' ', scopes: ['source.coffee', 'meta.class.instance.constructor']}
+          {value: 'foo.bar.Baz', scopes: ['source.coffee', 'meta.class.instance.constructor', 'entity.name.type.instance.coffee']}
+        ]
 
     describe "when the line doesn't match any patterns", ->
       it "returns the entire line as a single simple token with the grammar's scope", ->
         textGrammar = registry.grammarForScopeName('text.plain')
-        {tokens} = textGrammar.tokenizeLine("abc def")
+        {content} = textGrammar.tokenizeLine("abc def")
+        tokens = decodeContent(content)
         expect(tokens.length).toBe 1
 
     describe "when the line matches multiple patterns", ->
       it "returns multiple tokens, filling in regions that don't match patterns with tokens in the grammar's global scope", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine(" return new foo.bar.Baz ")
+        {content} = grammar.tokenizeLine(" return new foo.bar.Baz ")
 
-        expect(tokens.length).toBe 7
-
-        expect(tokens[0]).toEqual value: ' ', scopes: ['source.coffee']
-        expect(tokens[1]).toEqual value: 'return', scopes: ['source.coffee', 'keyword.control.coffee']
-        expect(tokens[2]).toEqual value: ' ', scopes: ['source.coffee']
-        expect(tokens[3]).toEqual value: 'new', scopes: ['source.coffee', 'meta.class.instance.constructor', 'keyword.operator.new.coffee']
-        expect(tokens[4]).toEqual value: ' ', scopes: ['source.coffee', 'meta.class.instance.constructor']
-        expect(tokens[5]).toEqual value: 'foo.bar.Baz', scopes: ['source.coffee', 'meta.class.instance.constructor', 'entity.name.type.instance.coffee']
-        expect(tokens[6]).toEqual value: ' ', scopes: ['source.coffee']
+        expect(decodeContent(content)).toEqual [
+          {value: ' ', scopes: ['source.coffee']}
+          {value: 'return', scopes: ['source.coffee', 'keyword.control.coffee']}
+          {value: ' ', scopes: ['source.coffee']}
+          {value: 'new', scopes: ['source.coffee', 'meta.class.instance.constructor', 'keyword.operator.new.coffee']}
+          {value: ' ', scopes: ['source.coffee', 'meta.class.instance.constructor']}
+          {value: 'foo.bar.Baz', scopes: ['source.coffee', 'meta.class.instance.constructor', 'entity.name.type.instance.coffee']}
+          {value: ' ', scopes: ['source.coffee']}
+        ]
 
     describe "when the line matches a pattern with optional capture groups", ->
       it "only returns tokens for capture groups that matched", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine("class Quicksort")
+        {content} = grammar.tokenizeLine("class Quicksort")
+        tokens = decodeContent(content)
+
         expect(tokens.length).toBe 3
         expect(tokens[0].value).toBe "class"
         expect(tokens[1].value).toBe " "
@@ -116,81 +124,93 @@ describe "Grammar tokenization", ->
     describe "when the line matches a rule with nested capture groups and lookahead capture groups beyond the scope of the overall match", ->
       it "creates distinct tokens for nested captures and does not return tokens beyond the scope of the overall capture", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine("  destroy: ->")
-        expect(tokens.length).toBe 6
-        expect(tokens[0]).toEqual(value: '  ', scopes: ["source.coffee"])
-        expect(tokens[1]).toEqual(value: 'destro', scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee"])
-        # this dangling 'y' with a duplicated scope looks wrong, but textmate yields the same behavior. probably a quirk in the coffee grammar.
-        expect(tokens[2]).toEqual(value: 'y', scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee", "entity.name.function.coffee"])
-        expect(tokens[3]).toEqual(value: ':', scopes: ["source.coffee", "keyword.operator.coffee"])
-        expect(tokens[4]).toEqual(value: ' ', scopes: ["source.coffee"])
-        expect(tokens[5]).toEqual(value: '->', scopes: ["source.coffee", "storage.type.function.coffee"])
+        {content} = grammar.tokenizeLine("  destroy: ->")
+
+        expect(decodeContent(content)).toEqual [
+          {value: '  ', scopes: ["source.coffee"]}
+          {value: 'destro', scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee"]}
+          # duplicated scope looks wrong, but textmate yields the same behavior. probably a quirk in the coffee grammar.
+          {value: 'y', scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee", "entity.name.function.coffee"]}
+          {value: ':', scopes: ["source.coffee", "keyword.operator.coffee"]}
+          {value: ' ', scopes: ["source.coffee"]}
+          {value: '->', scopes: ["source.coffee", "storage.type.function.coffee"]}
+        ]
 
     describe "when the line matches a pattern that includes a rule", ->
       it "returns tokens based on the included rule", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine("7777777")
-        expect(tokens.length).toBe 1
-        expect(tokens[0]).toEqual value: '7777777', scopes: ['source.coffee', 'constant.numeric.coffee']
+        {content} = grammar.tokenizeLine("7777777")
+        expect(decodeContent(content)).toEqual [
+          {value: '7777777', scopes: ['source.coffee', 'constant.numeric.coffee']}
+        ]
 
     describe "when the line is an interpolated string", ->
       it "returns the correct tokens", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine('"the value is #{@x} my friend"')
+        {content} = grammar.tokenizeLine('"the value is #{@x} my friend"')
 
-        expect(tokens[0]).toEqual value: '"', scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]
-        expect(tokens[1]).toEqual value: "the value is ", scopes: ["source.coffee","string.quoted.double.coffee"]
-        expect(tokens[2]).toEqual value: '#{', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]
-        expect(tokens[3]).toEqual value: "@x", scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","variable.other.readwrite.instance.coffee"]
-        expect(tokens[4]).toEqual value: "}", scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]
-        expect(tokens[5]).toEqual value: " my friend", scopes: ["source.coffee","string.quoted.double.coffee"]
-        expect(tokens[6]).toEqual value: '"', scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.end.coffee"]
+        expect(decodeContent(content)).toEqual [
+          {value: '"', scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]}
+          {value: "the value is ", scopes: ["source.coffee","string.quoted.double.coffee"]}
+          {value: '#{', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]}
+          {value: "@x", scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","variable.other.readwrite.instance.coffee"]}
+          {value: "}", scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]}
+          {value: " my friend", scopes: ["source.coffee","string.quoted.double.coffee"]}
+          {value: '"', scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.end.coffee"]}
+        ]
 
     describe "when the line has an interpolated string inside an interpolated string", ->
       it "returns the correct tokens", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine('"#{"#{@x}"}"')
+        {content} = grammar.tokenizeLine('"#{"#{@x}"}"')
 
-        expect(tokens[0]).toEqual value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]
-        expect(tokens[1]).toEqual value: '#{', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]
-        expect(tokens[2]).toEqual value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]
-        expect(tokens[3]).toEqual value: '#{', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]
-        expect(tokens[4]).toEqual value: '@x', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","source.coffee.embedded.source","variable.other.readwrite.instance.coffee"]
-        expect(tokens[5]).toEqual value: '}',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]
-        expect(tokens[6]).toEqual value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","punctuation.definition.string.end.coffee"]
-        expect(tokens[7]).toEqual value: '}',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]
-        expect(tokens[8]).toEqual value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.end.coffee"]
+        expect(decodeContent(content)).toEqual [
+          {value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]}
+          {value: '#{', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]}
+          {value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]}
+          {value: '#{', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]}
+          {value: '@x', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","source.coffee.embedded.source","variable.other.readwrite.instance.coffee"]}
+          {value: '}',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]}
+          {value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","punctuation.definition.string.end.coffee"]}
+          {value: '}',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]}
+          {value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.end.coffee"]}
+        ]
 
     describe "when the line is empty", ->
       it "returns a single token which has the global scope", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine('')
-        expect(tokens[0]).toEqual value: '',  scopes: ["source.coffee"]
+        {content} = grammar.tokenizeLine('')
+        expect(decodeContent(content)).toEqual [{value: '',  scopes: ["source.coffee"]}]
 
     describe "when the line matches no patterns", ->
       it "does not infinitely loop", ->
         grammar = registry.grammarForScopeName('text.plain')
-        {tokens} = grammar.tokenizeLine('hoo')
-        expect(tokens.length).toBe 1
-        expect(tokens[0]).toEqual value: 'hoo',  scopes: ["text.plain", "meta.paragraph.text"]
+        {content} = grammar.tokenizeLine('hoo')
+        expect(decodeContent(content)).toEqual [{value: 'hoo',  scopes: ["text.plain", "meta.paragraph.text"]}]
 
     describe "when the line matches a pattern with a 'contentName'", ->
       it "creates tokens using the content of contentName as the token name", ->
         grammar = registry.grammarForScopeName('text.plain')
-        {tokens} = grammar.tokenizeLine('ok, cool')
-        expect(tokens[0]).toEqual value: 'ok, cool',  scopes: ["text.plain", "meta.paragraph.text"]
+        {content} = grammar.tokenizeLine('ok, cool')
+        expect(decodeContent(content)).toEqual [{value: 'ok, cool',  scopes: ["text.plain", "meta.paragraph.text"]}]
 
         grammar = registry.grammarForScopeName('text.plain')
-        {tokens} = grammar.tokenizeLine(' ok, cool')
-        expect(tokens[0]).toEqual value: ' ',  scopes: ["text.plain"]
-        expect(tokens[1]).toEqual value: 'ok, cool',  scopes: ["text.plain", "meta.paragraph.text"]
+        {content} = grammar.tokenizeLine(' ok, cool')
+
+        expect(decodeContent(content)).toEqual [
+          {value: ' ',  scopes: ["text.plain"]}
+          {value: 'ok, cool', scopes: ["text.plain", "meta.paragraph.text"]}
+        ]
 
         loadGrammarSync("content-name.json")
 
         grammar = registry.grammarForScopeName("source.test")
         lines = grammar.tokenizeLines "#if\ntest\n#endif"
 
-        [line1, line2, line3] = lines
+        scopes = []
+        line1 = decodeContent(lines[0], scopes)
+        line2 = decodeContent(lines[1], scopes)
+        line3 = decodeContent(lines[2], scopes)
 
         expect(line1.length).toBe 1
         expect(line1[0].value).toEqual "#if"
@@ -206,12 +226,14 @@ describe "Grammar tokenization", ->
         expect(line3[1].value).toEqual ""
         expect(line3[1].scopes).toEqual ["source.test", "all"]
 
-        {tokens} = grammar.tokenizeLine "test"
+        {content} = grammar.tokenizeLine "test"
+        tokens = decodeContent(content)
         expect(tokens.length).toBe 1
         expect(tokens[0].value).toEqual "test"
         expect(tokens[0].scopes).toEqual ["source.test", "all", "middle"]
 
-        {tokens} = grammar.tokenizeLine " test"
+        {content} = grammar.tokenizeLine " test"
+        tokens = decodeContent(content)
         expect(tokens.length).toBe 2
         expect(tokens[0].value).toEqual " "
         expect(tokens[0].scopes).toEqual ["source.test", "all"]
@@ -221,17 +243,20 @@ describe "Grammar tokenization", ->
     describe "when the line matches a pattern with no `name` or `contentName`", ->
       it "creates tokens without adding a new scope", ->
         grammar = registry.grammarForScopeName('source.ruby')
-        {tokens} = grammar.tokenizeLine('%w|oh \\look|')
+        {content} = grammar.tokenizeLine('%w|oh \\look|')
+        tokens = decodeContent(content)
+
         expect(tokens.length).toBe 5
-        expect(tokens[0]).toEqual value: '%w|',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
-        expect(tokens[1]).toEqual value: 'oh ',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby"]
-        expect(tokens[2]).toEqual value: '\\l',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby"]
-        expect(tokens[3]).toEqual value: 'ook',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby"]
+        expect(tokens[0]).toEqual value: '%w|', scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
+        expect(tokens[1]).toEqual value: 'oh ', scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby"]
+        expect(tokens[2]).toEqual value: '\\l', scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby"]
+        expect(tokens[3]).toEqual value: 'ook', scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby"]
 
     describe "when the line matches a begin/end pattern", ->
       it "returns tokens based on the beginCaptures, endCaptures and the child scope", ->
         grammar = registry.grammarForScopeName('source.coffee')
-        {tokens} = grammar.tokenizeLine("'''single-quoted heredoc'''")
+        {content} = grammar.tokenizeLine("'''single-quoted heredoc'''")
+        tokens = decodeContent(content)
 
         expect(tokens.length).toBe 3
 
@@ -242,8 +267,12 @@ describe "Grammar tokenization", ->
       describe "when the pattern spans multiple lines", ->
         it "uses the ruleStack returned by the first line to parse the second line", ->
           grammar = registry.grammarForScopeName('source.coffee')
-          {tokens: firstTokens, ruleStack} = grammar.tokenizeLine("'''single-quoted")
-          {tokens: secondTokens, ruleStack} = grammar.tokenizeLine("heredoc'''", ruleStack)
+          {content: firstTokens, ruleStack} = grammar.tokenizeLine("'''single-quoted")
+          {content: secondTokens, ruleStack} = grammar.tokenizeLine("heredoc'''", ruleStack)
+
+          scopes = []
+          firstTokens = decodeContent(firstTokens, scopes)
+          secondTokens = decodeContent(secondTokens, scopes)
 
           expect(firstTokens.length).toBe 2
           expect(secondTokens.length).toBe 2
@@ -257,7 +286,8 @@ describe "Grammar tokenization", ->
       describe "when the pattern contains sub-patterns", ->
         it "returns tokens within the begin/end scope based on the sub-patterns", ->
           grammar = registry.grammarForScopeName('source.coffee')
-          {tokens} = grammar.tokenizeLine('"""heredoc with character escape \\t"""')
+          {content} = grammar.tokenizeLine('"""heredoc with character escape \\t"""')
+          tokens = decodeContent(content)
 
           expect(tokens.length).toBe 4
 
@@ -277,6 +307,13 @@ describe "Grammar tokenization", ->
             { some }excentricSyntax }
           """
 
+          scopes = []
+          lines[0] = decodeContent(lines[0], scopes)
+          lines[1] = decodeContent(lines[1], scopes)
+          lines[2] = decodeContent(lines[2], scopes)
+          lines[3] = decodeContent(lines[3], scopes)
+          lines[4] = decodeContent(lines[4], scopes)
+
           expect(lines[1][2]).toEqual value: "}excentricSyntax", scopes: ['source.apply-end-pattern-last', 'end-pattern-last-env', 'scope', 'excentric']
           expect(lines[4][2]).toEqual value: "}", scopes: ['source.apply-end-pattern-last', 'normal-env', 'scope']
           expect(lines[4][3]).toEqual value: "excentricSyntax }", scopes: ['source.apply-end-pattern-last', 'normal-env']
@@ -284,7 +321,9 @@ describe "Grammar tokenization", ->
       describe "when the end pattern contains a back reference", ->
         it "constructs the end rule based on its back-references to captures in the begin rule", ->
           grammar = registry.grammarForScopeName('source.ruby')
-          {tokens} = grammar.tokenizeLine('%w|oh|,')
+          {content} = grammar.tokenizeLine('%w|oh|,')
+          tokens = decodeContent(content)
+
           expect(tokens.length).toBe 4
           expect(tokens[0]).toEqual value: '%w|',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
           expect(tokens[1]).toEqual value: 'oh',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby"]
@@ -293,7 +332,9 @@ describe "Grammar tokenization", ->
 
         it "allows the rule containing that end pattern to be pushed to the stack multiple times", ->
           grammar = registry.grammarForScopeName('source.ruby')
-          {tokens} = grammar.tokenizeLine('%Q+matz had some #{%Q-crazy ideas-} for ruby syntax+ # damn.')
+          {content} = grammar.tokenizeLine('%Q+matz had some #{%Q-crazy ideas-} for ruby syntax+ # damn.')
+          tokens = decodeContent(content)
+
           expect(tokens[0]).toEqual value: '%Q+', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby","punctuation.definition.string.begin.ruby"]
           expect(tokens[1]).toEqual value: 'matz had some ', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby"]
           expect(tokens[2]).toEqual value: '#{', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby","meta.embedded.line.ruby","punctuation.section.embedded.begin.ruby"]
@@ -314,7 +355,8 @@ describe "Grammar tokenization", ->
             loadGrammarSync('ruby-on-rails.json')
 
             grammar = registry.grammarForScopeName('text.html.ruby')
-            {tokens} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
+            {content} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
+            tokens = decodeContent(content)
 
             expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
             expect(tokens[1]).toEqual value: 'div', scopes: ["text.html.ruby","meta.tag.block.any.html","entity.name.tag.block.any.html"]
@@ -348,12 +390,14 @@ describe "Grammar tokenization", ->
             grammarUpdatedHandler = jasmine.createSpy("grammarUpdatedHandler")
             grammar.onDidUpdate grammarUpdatedHandler
 
-            {tokens} = grammar.tokenizeLine("<div class='name'><% <<-SQL select * from users;")
+            {content} = grammar.tokenizeLine("<div class='name'><% <<-SQL select * from users;")
+            tokens = decodeContent(content)
             expect(tokens[12].value).toBe " select * from users;"
 
             loadGrammarSync('sql.json')
             expect(grammarUpdatedHandler).toHaveBeenCalled()
-            {tokens} = grammar.tokenizeLine("<div class='name'><% <<-SQL select * from users;")
+            {content} = grammar.tokenizeLine("<div class='name'><% <<-SQL select * from users;")
+            tokens = decodeContent(content)
             expect(tokens[12].value).toBe " "
             expect(tokens[13].value).toBe "select"
 
@@ -364,14 +408,16 @@ describe "Grammar tokenization", ->
             loadGrammarSync('ruby-on-rails.json')
 
             grammar = registry.grammarForScopeName('text.html.ruby')
-            {tokens} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
+            {content} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
+            tokens = decodeContent(content)
             expect(tokens[0]).toEqual value: "<div class='name'>", scopes: ["text.html.ruby"]
             expect(tokens[1]).toEqual value: '<%=', scopes: ["text.html.ruby","source.ruby.rails.embedded.html","punctuation.section.embedded.ruby"]
             expect(tokens[2]).toEqual value: ' ', scopes: ["text.html.ruby","source.ruby.rails.embedded.html"]
             expect(tokens[3]).toEqual value: 'User', scopes: ["text.html.ruby","source.ruby.rails.embedded.html","support.class.ruby"]
 
             loadGrammarSync('html.json')
-            {tokens} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
+            {content} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
+            tokens = decodeContent(content)
             expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
             expect(tokens[1]).toEqual value: 'div', scopes: ["text.html.ruby","meta.tag.block.any.html","entity.name.tag.block.any.html"]
             expect(tokens[2]).toEqual value: ' ', scopes: ["text.html.ruby","meta.tag.block.any.html"]
@@ -386,7 +432,8 @@ describe "Grammar tokenization", ->
 
     it "can parse a grammar with newline characters in its regular expressions (regression)", ->
       grammar = loadGrammarSync('imaginary.cson')
-      {tokens, ruleStack} = grammar.tokenizeLine("// a singleLineComment")
+      {content, ruleStack} = grammar.tokenizeLine("// a singleLineComment")
+      tokens = decodeContent(content)
       expect(ruleStack.length).toBe 1
       expect(ruleStack[0].scopeName).toBe "source.imaginaryLanguage"
 
@@ -397,39 +444,41 @@ describe "Grammar tokenization", ->
 
     it "can parse multiline text using a grammar containing patterns with newlines", ->
       grammar = loadGrammarSync('multiline.cson')
-      tokens = grammar.tokenizeLines('Xy\\\nzX')
+      lines = grammar.tokenizeLines('Xy\\\nzX')
+      scopes = []
+      lines[0] = decodeContent(lines[0], scopes)
+      lines[1] = decodeContent(lines[1], scopes)
 
       # Line 0
-      expect(tokens[0][0]).toEqual
+      expect(lines[0][0]).toEqual
         value: 'X'
         scopes: ['source.multilineLanguage', 'outside-x', 'start']
 
-      expect(tokens[0][1]).toEqual
+      expect(lines[0][1]).toEqual
         value: 'y'
         scopes: ['source.multilineLanguage', 'outside-x']
 
-      expect(tokens[0][2]).toEqual
+      expect(lines[0][2]).toEqual
         value: '\\'
         scopes: ['source.multilineLanguage', 'outside-x', 'inside-x']
 
-      expect(tokens[0][3]).not.toBeDefined()
+      expect(lines[0][3]).not.toBeDefined()
 
       # Line 1
-      expect(tokens[1][0]).toEqual
+      expect(lines[1][0]).toEqual
         value: 'z'
         scopes: ['source.multilineLanguage', 'outside-x']
 
-      expect(tokens[1][1]).toEqual
+      expect(lines[1][1]).toEqual
         value: 'X'
         scopes: ['source.multilineLanguage', 'outside-x', 'end']
 
-      expect(tokens[1][2]).not.toBeDefined()
-
+      expect(lines[1][2]).not.toBeDefined()
 
     it "does not loop infinitely (regression)", ->
       grammar = registry.grammarForScopeName('source.js')
-      {tokens, ruleStack} = grammar.tokenizeLine("// line comment")
-      {tokens, ruleStack} = grammar.tokenizeLine(" // second line comment with a single leading space", ruleStack)
+      {content, ruleStack} = grammar.tokenizeLine("// line comment")
+      {content, ruleStack} = grammar.tokenizeLine(" // second line comment with a single leading space", ruleStack)
 
     describe "when inside a C block", ->
       beforeEach ->
@@ -438,11 +487,13 @@ describe "Grammar tokenization", ->
         grammar = registry.grammarForScopeName('source.c')
 
       it "correctly parses a method. (regression)", ->
-        {tokens, ruleStack} = grammar.tokenizeLine("if(1){m()}")
+        {content, ruleStack} = grammar.tokenizeLine("if(1){m()}")
+        tokens = decodeContent(content)
         expect(tokens[5]).toEqual value: "m", scopes: ["source.c", "meta.block.c", "meta.function-call.c", "support.function.any-method.c"]
 
       it "correctly parses nested blocks. (regression)", ->
-        {tokens, ruleStack} = grammar.tokenizeLine("if(1){if(1){m()}}")
+        {content, ruleStack} = grammar.tokenizeLine("if(1){if(1){m()}}")
+        tokens = decodeContent(content)
         expect(tokens[5]).toEqual value: "if", scopes: ["source.c", "meta.block.c", "keyword.control.c"]
         expect(tokens[10]).toEqual value: "m", scopes: ["source.c", "meta.block.c", "meta.block.c", "meta.function-call.c", "support.function.any-method.c"]
 
@@ -450,7 +501,8 @@ describe "Grammar tokenization", ->
       it "aborts tokenization", ->
         spyOn(console, 'error')
         grammar = loadGrammarSync('infinite-loop.cson')
-        {tokens} = grammar.tokenizeLine("abc")
+        {content} = grammar.tokenizeLine("abc")
+        tokens = decodeContent(content)
         expect(tokens[0].value).toBe "a"
         expect(tokens[1].value).toBe "bc"
         expect(console.error).toHaveBeenCalled()
@@ -459,7 +511,8 @@ describe "Grammar tokenization", ->
       it "does not special handle the back references and instead allows oniguruma to resolve them", ->
         loadGrammarSync('scss.json')
         grammar = registry.grammarForScopeName('source.css.scss')
-        {tokens} = grammar.tokenizeLine("@mixin x() { -moz-selector: whatever; }")
+        {content} = grammar.tokenizeLine("@mixin x() { -moz-selector: whatever; }")
+        tokens = decodeContent(content)
         expect(tokens[9]).toEqual value: "-moz-selector", scopes: ["source.css.scss", "meta.property-list.scss", "meta.property-name.scss"]
 
     describe "when a line has more tokens than `maxTokensPerLine`", ->
@@ -467,7 +520,8 @@ describe "Grammar tokenization", ->
         grammar = registry.grammarForScopeName('source.js')
         originalRuleStack = grammar.tokenizeLine('').ruleStack
         spyOn(grammar, 'getMaxTokensPerLine').andCallFake -> 5
-        {tokens, ruleStack} = grammar.tokenizeLine("var x = /[a-z]/;", originalRuleStack)
+        {content, ruleStack} = grammar.tokenizeLine("var x = /[a-z]/;", originalRuleStack)
+        tokens = decodeContent(content)
         expect(tokens.length).toBe 6
         expect(tokens[5].value).toBe "[a-z]/;"
         expect(ruleStack).toEqual originalRuleStack
@@ -476,7 +530,8 @@ describe "Grammar tokenization", ->
     describe "when a grammar has a capture with patterns", ->
       it "matches the patterns and includes the scope specified as the pattern's match name", ->
         grammar = registry.grammarForScopeName('text.html.php')
-        {tokens} = grammar.tokenizeLine("<?php public final function meth() {} ?>")
+        {content} = grammar.tokenizeLine("<?php public final function meth() {} ?>")
+        tokens = decodeContent(content)
 
         expect(tokens[2].value).toBe "public"
         expect(tokens[2].scopes).toEqual ["text.html.php", "meta.embedded.line.php", "source.php", "meta.function.php", "storage.modifier.php"]
@@ -495,7 +550,8 @@ describe "Grammar tokenization", ->
 
       it "ignores child captures of a capture with patterns", ->
         grammar = loadGrammarSync('nested-captures.cson')
-        {tokens} = grammar.tokenizeLine("ab")
+        {content} = grammar.tokenizeLine("ab")
+        tokens = decodeContent(content)
 
         expect(tokens[0].value).toBe "ab"
         expect(tokens[0].scopes).toEqual ["nested", "text", "a"]
@@ -503,7 +559,8 @@ describe "Grammar tokenization", ->
     describe "when the grammar has injections", ->
       it "correctly includes the injected patterns when tokenizing", ->
         grammar = registry.grammarForScopeName('text.html.php')
-        {tokens} = grammar.tokenizeLine("<div><?php function hello() {} ?></div>")
+        {content} = grammar.tokenizeLine("<div><?php function hello() {} ?></div>")
+        tokens = decodeContent(content)
 
         expect(tokens[3].value).toBe "<?php"
         expect(tokens[3].scopes).toEqual ["text.html.php", "meta.embedded.line.php", "punctuation.section.embedded.begin.php"]
@@ -529,14 +586,16 @@ describe "Grammar tokenization", ->
     describe "when the grammar's pattern name has a group number in it", ->
       it "replaces the group number with the matched captured text", ->
         grammar = loadGrammarSync('hyperlink.json')
-        {tokens} = grammar.tokenizeLine("https://github.com")
+        {content} = grammar.tokenizeLine("https://github.com")
+        tokens = decodeContent(content)
         expect(tokens[0].scopes).toEqual ["text.hyperlink", "markup.underline.link.https.hyperlink"]
 
     describe "when the grammar has an injection selector", ->
       it "includes the grammar's patterns when the selector matches the current scope in other grammars", ->
         loadGrammarSync('hyperlink.json')
         grammar = registry.grammarForScopeName("source.js")
-        {tokens} = grammar.tokenizeLine("var i; // http://github.com")
+        {content} = grammar.tokenizeLine("var i; // http://github.com")
+        tokens = decodeContent(content)
 
         expect(tokens[0].value).toBe "var"
         expect(tokens[0].scopes).toEqual ["source.js", "storage.modifier.js"]
@@ -547,22 +606,20 @@ describe "Grammar tokenization", ->
     describe "when the position doesn't advance and rule includes $self and matches itself", ->
       it "tokenizes the entire line using the rule", ->
         grammar = loadGrammarSync('forever.cson')
-        {tokens} = grammar.tokenizeLine("forever and ever")
+        {content} = grammar.tokenizeLine("forever and ever")
+        tokens = decodeContent(content)
 
         expect(tokens.length).toBe 1
         expect(tokens[0].value).toBe "forever and ever"
         expect(tokens[0].scopes).toEqual ["source.forever", "text"]
 
     describe "${capture:/command} style pattern names", ->
-      lines = null
-
-      beforeEach ->
+      it "replaces the number with the capture group and translates the text", ->
         loadGrammarSync('todo.json')
         grammar = registry.grammarForScopeName('source.ruby')
-        lines = grammar.tokenizeLines "# TODO be nicer"
+        {content} = grammar.tokenizeLine "# TODO be nicer"
+        tokens = decodeContent(content)
 
-      it "replaces the number with the capture group and translates the text", ->
-        tokens = lines[0]
         expect(tokens[2].value).toEqual "TODO"
         expect(tokens[2].scopes).toEqual ["source.ruby", "comment.line.number-sign.ruby", "storage.type.class.todo"]
 
@@ -570,12 +627,14 @@ describe "Grammar tokenization", ->
       it "replaces the number with the capture group and translates the text", ->
         loadGrammarSync('makefile.json')
         grammar = registry.grammarForScopeName('source.makefile')
-        tokens = grammar.tokenizeLines("ifeq")[0]
+        content = grammar.tokenizeLines("ifeq")[0]
+        tokens = decodeContent(content)
         expect(tokens.length).toBe 1
         expect(tokens[0].value).toEqual "ifeq"
         expect(tokens[0].scopes).toEqual ["source.makefile", "meta.scope.conditional.makefile", "keyword.control.ifeq.makefile"]
 
-        tokens = grammar.tokenizeLines("ifeq (")[0]
+        content = grammar.tokenizeLines("ifeq (")[0]
+        tokens = decodeContent(content)
         expect(tokens.length).toBe 2
         expect(tokens[0].value).toEqual "ifeq"
         expect(tokens[0].scopes).toEqual ["source.makefile", "meta.scope.conditional.makefile", "keyword.control.ifeq.makefile"]
@@ -585,7 +644,8 @@ describe "Grammar tokenization", ->
       it "removes leading dot characters from the replaced capture index placeholder", ->
         loadGrammarSync('makefile.json')
         grammar = registry.grammarForScopeName('source.makefile')
-        {tokens}  = grammar.tokenizeLine(".PHONY:")
+        {content}  = grammar.tokenizeLine(".PHONY:")
+        tokens = decodeContent(content)
         expect(tokens.length).toBe 2
         expect(tokens[0].value).toEqual ".PHONY"
         expect(tokens[0].scopes).toEqual ["source.makefile", "meta.scope.target.makefile", "support.function.target.PHONY.makefile"]
@@ -600,6 +660,9 @@ describe "Grammar tokenization", ->
           longggggggggggggggggggggggggggggggggggggggggggggggg
           # Please enter the commit message for your changes. Lines starting
         """
+        scopes = []
+        lines[0] = decodeContent(lines[0], scopes)
+        lines[1] = decodeContent(lines[1], scopes)
 
       it "correctly parses a long line", ->
         tokens = lines[0]
@@ -619,6 +682,9 @@ describe "Grammar tokenization", ->
           #include "a.h"
           #include "b.h"
         """
+        scopes = []
+        lines[0] = decodeContent(lines[0], scopes)
+        lines[1] = decodeContent(lines[1], scopes)
 
       it "correctly parses the first include line", ->
         tokens = lines[0]
@@ -642,6 +708,10 @@ describe "Grammar tokenization", ->
             "b" => "c",
           }
         """
+        scopes = []
+        lines[0] = decodeContent(lines[0], scopes)
+        lines[1] = decodeContent(lines[1], scopes)
+        lines[2] = decodeContent(lines[2], scopes)
 
       it "doesn't loop infinitely (regression)", ->
         expect(_.pluck(lines[0], 'value').join('')).toBe 'a = {'
@@ -660,6 +730,10 @@ describe "Grammar tokenization", ->
           NSString *a = @"a\\nb";
           }
         """
+        scopes = []
+        lines[0] = decodeContent(lines[0], scopes)
+        lines[1] = decodeContent(lines[1], scopes)
+        lines[2] = decodeContent(lines[2], scopes)
 
       it "correctly parses variable type when it is a built-in Cocoa class", ->
         tokens = lines[1]
@@ -688,6 +762,10 @@ describe "Grammar tokenization", ->
           //comment
           }
         """
+        scopes = []
+        lines[0] = decodeContent(lines[0], scopes)
+        lines[1] = decodeContent(lines[1], scopes)
+        lines[2] = decodeContent(lines[2], scopes)
 
         tokens = lines[1]
         expect(tokens[0].scopes).toEqual ["source.java", "comment.line.double-slash.java", "punctuation.definition.comment.java"]
@@ -696,7 +774,8 @@ describe "Grammar tokenization", ->
         expect(tokens[1].value).toEqual 'comment'
 
       it "correctly parses nested method calls", ->
-        tokens = grammar.tokenizeLines('a(b(new Object[0]));')[0]
+        content = grammar.tokenizeLines('a(b(new Object[0]));')[0]
+        tokens = decodeContent(content)
         lastToken = _.last(tokens)
         expect(lastToken.scopes).toEqual ['source.java', 'punctuation.terminator.java']
         expect(lastToken.value).toEqual ';'
@@ -704,7 +783,8 @@ describe "Grammar tokenization", ->
     describe "HTML (Ruby - ERB)", ->
       it "correctly parses strings inside tags", ->
         grammar = registry.grammarForScopeName('text.html.erb')
-        {tokens} = grammar.tokenizeLine '<% page_title "My Page" %>'
+        {content} = grammar.tokenizeLine '<% page_title "My Page" %>'
+        tokens = decodeContent(content)
 
         expect(tokens[2].value).toEqual '"'
         expect(tokens[2].scopes).toEqual ["text.html.erb", "meta.embedded.line.erb", "source.ruby", "string.quoted.double.ruby", "punctuation.definition.string.begin.ruby"]
@@ -718,19 +798,20 @@ describe "Grammar tokenization", ->
         loadGrammarSync('ruby-on-rails.json')
 
         grammar = registry.grammarForScopeName('text.html.erb')
-        [tokens] = grammar.tokenizeLines '<%>'
+        content = grammar.tokenizeLines('<%>')[0]
+        tokens = decodeContent(content)
+
         expect(tokens.length).toBe 1
         expect(tokens[0].value).toEqual '<%>'
         expect(tokens[0].scopes).toEqual ["text.html.erb"]
 
     describe "Unicode support", ->
       describe "Surrogate pair characters", ->
-        beforeEach ->
-          grammar = registry.grammarForScopeName('source.js')
-          lines = grammar.tokenizeLines "'\uD835\uDF97'"
-
         it "correctly parses JavaScript strings containing surrogate pair characters", ->
-          tokens = lines[0]
+          grammar = registry.grammarForScopeName('source.js')
+          {content} = grammar.tokenizeLine "'\uD835\uDF97'"
+          tokens = decodeContent(content)
+
           expect(tokens.length).toBe 3
           expect(tokens[0].value).toBe "'"
           expect(tokens[1].value).toBe "\uD835\uDF97"
@@ -740,7 +821,8 @@ describe "Grammar tokenization", ->
         it "correctly parses tokens starting after them", ->
           loadGrammarSync('json.json')
           grammar = registry.grammarForScopeName('source.json')
-          {tokens} = grammar.tokenizeLine '{"\u2026": 1}'
+          {content} = grammar.tokenizeLine '{"\u2026": 1}'
+          tokens = decodeContent(content)
 
           expect(tokens.length).toBe 8
           expect(tokens[6].value).toBe '1'
@@ -750,6 +832,9 @@ describe "Grammar tokenization", ->
       it "parses import blocks correctly", ->
         grammar = registry.grammarForScopeName('source.python')
         lines = grammar.tokenizeLines "import a\nimport b"
+        scopes = []
+        lines[0] = decodeContent(lines[0], scopes)
+        lines[1] = decodeContent(lines[1], scopes)
 
         line1 = lines[0]
         expect(line1.length).toBe 3
@@ -786,6 +871,13 @@ describe "Grammar tokenization", ->
               </head>
             </html>
           """
+          scopes = []
+          lines[0] = decodeContent(lines[0], scopes)
+          lines[1] = decodeContent(lines[1], scopes)
+          lines[2] = decodeContent(lines[2], scopes)
+          lines[3] = decodeContent(lines[3], scopes)
+          lines[4] = decodeContent(lines[4], scopes)
+
 
           line4 = lines[4]
           expect(line4[4].value).toEqual "blue"
@@ -802,7 +894,8 @@ describe "Grammar tokenization", ->
       spyOn(console, 'error')
       loadGrammarSync("loops.json")
       grammar = registry.grammarForScopeName("source.loops")
-      {ruleStack, tokens} = grammar.tokenizeLine('test')
+      {content, ruleStack} = grammar.tokenizeLine('test')
+      tokens = decodeContent(content)
 
       expect(ruleStack.length).toBe 1
       expect(console.error.callCount).toBe 1

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -28,7 +28,7 @@ describe "Grammar tokenization", ->
       emptyRegistry = new GrammarRegistry()
       grammar = emptyRegistry.selectGrammar('foo.js', '')
       {line, tags} = grammar.tokenizeLine('a = 1;')
-      tokens = emptyRegistry.decodeContent(line, tags)
+      tokens = emptyRegistry.decodeTokens(line, tags)
       expect(tokens.length).toBe 1
       expect(tokens[0].value).toBe 'a = 1;'
       expect(tokens[0].scopes).toEqual ['text.plain.null-grammar']
@@ -39,7 +39,7 @@ describe "Grammar tokenization", ->
 
       grammar = registry.nullGrammar
       {line, tags} = grammar.tokenizeLine('http://github.com')
-      tokens = registry.decodeContent(line, tags)
+      tokens = registry.decodeTokens(line, tags)
       expect(tokens.length).toBe 1
       expect(tokens[0].value).toEqual 'http://github.com'
       expect(tokens[0].scopes).toEqual ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
@@ -51,7 +51,7 @@ describe "Grammar tokenization", ->
       expect(grammar).not.toBeNull()
 
       {line, tags} = grammar.tokenizeLine('hello world!')
-      tokens = registry.decodeContent(line, tags)
+      tokens = registry.decodeTokens(line, tags)
       expect(tokens.length).toBe 4
 
       expect(tokens[0].value).toBe 'hello'
@@ -72,7 +72,7 @@ describe "Grammar tokenization", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine("return")
 
-        expect(registry.decodeContent(line, tags)).toEqual [
+        expect(registry.decodeTokens(line, tags)).toEqual [
           {value: 'return', scopes: ['source.coffee', 'keyword.control.coffee']}
         ]
 
@@ -80,7 +80,7 @@ describe "Grammar tokenization", ->
       it "returns a single token with the correct scope", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine("new foo.bar.Baz")
-        expect(registry.decodeContent(line, tags)).toEqual [
+        expect(registry.decodeTokens(line, tags)).toEqual [
           {value: 'new', scopes: ['source.coffee', 'meta.class.instance.constructor', 'keyword.operator.new.coffee']}
           {value: ' ', scopes: ['source.coffee', 'meta.class.instance.constructor']}
           {value: 'foo.bar.Baz', scopes: ['source.coffee', 'meta.class.instance.constructor', 'entity.name.type.instance.coffee']}
@@ -90,7 +90,7 @@ describe "Grammar tokenization", ->
       it "returns the entire line as a single simple token with the grammar's scope", ->
         textGrammar = registry.grammarForScopeName('text.plain')
         {line, tags} = textGrammar.tokenizeLine("abc def")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens.length).toBe 1
 
     describe "when the line matches multiple patterns", ->
@@ -98,7 +98,7 @@ describe "Grammar tokenization", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine(" return new foo.bar.Baz ")
 
-        expect(registry.decodeContent(line, tags)).toEqual [
+        expect(registry.decodeTokens(line, tags)).toEqual [
           {value: ' ', scopes: ['source.coffee']}
           {value: 'return', scopes: ['source.coffee', 'keyword.control.coffee']}
           {value: ' ', scopes: ['source.coffee']}
@@ -112,7 +112,7 @@ describe "Grammar tokenization", ->
       it "only returns tokens for capture groups that matched", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine("class Quicksort")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens.length).toBe 3
         expect(tokens[0].value).toBe "class"
@@ -124,7 +124,7 @@ describe "Grammar tokenization", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine("  destroy: ->")
 
-        expect(registry.decodeContent(line, tags)).toEqual [
+        expect(registry.decodeTokens(line, tags)).toEqual [
           {value: '  ', scopes: ["source.coffee"]}
           {value: 'destro', scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee"]}
           # duplicated scope looks wrong, but textmate yields the same behavior. probably a quirk in the coffee grammar.
@@ -138,7 +138,7 @@ describe "Grammar tokenization", ->
       it "returns tokens based on the included rule", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine("7777777")
-        expect(registry.decodeContent(line, tags)).toEqual [
+        expect(registry.decodeTokens(line, tags)).toEqual [
           {value: '7777777', scopes: ['source.coffee', 'constant.numeric.coffee']}
         ]
 
@@ -147,7 +147,7 @@ describe "Grammar tokenization", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine('"the value is #{@x} my friend"')
 
-        expect(registry.decodeContent(line, tags)).toEqual [
+        expect(registry.decodeTokens(line, tags)).toEqual [
           {value: '"', scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]}
           {value: "the value is ", scopes: ["source.coffee","string.quoted.double.coffee"]}
           {value: '#{', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]}
@@ -162,7 +162,7 @@ describe "Grammar tokenization", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine('"#{"#{@x}"}"')
 
-        expect(registry.decodeContent(line, tags)).toEqual [
+        expect(registry.decodeTokens(line, tags)).toEqual [
           {value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]}
           {value: '#{', scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","punctuation.section.embedded.coffee"]}
           {value: '"',  scopes: ["source.coffee","string.quoted.double.coffee","source.coffee.embedded.source","string.quoted.double.coffee","punctuation.definition.string.begin.coffee"]}
@@ -178,24 +178,24 @@ describe "Grammar tokenization", ->
       it "returns a single token which has the global scope", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine('')
-        expect(registry.decodeContent(line, tags)).toEqual [{value: '',  scopes: ["source.coffee"]}]
+        expect(registry.decodeTokens(line, tags)).toEqual [{value: '',  scopes: ["source.coffee"]}]
 
     describe "when the line matches no patterns", ->
       it "does not infinitely loop", ->
         grammar = registry.grammarForScopeName('text.plain')
         {line, tags} = grammar.tokenizeLine('hoo')
-        expect(registry.decodeContent(line, tags)).toEqual [{value: 'hoo',  scopes: ["text.plain", "meta.paragraph.text"]}]
+        expect(registry.decodeTokens(line, tags)).toEqual [{value: 'hoo',  scopes: ["text.plain", "meta.paragraph.text"]}]
 
     describe "when the line matches a pattern with a 'contentName'", ->
       it "creates tokens using the content of contentName as the token name", ->
         grammar = registry.grammarForScopeName('text.plain')
         {line, tags} = grammar.tokenizeLine('ok, cool')
-        expect(registry.decodeContent(line, tags)).toEqual [{value: 'ok, cool',  scopes: ["text.plain", "meta.paragraph.text"]}]
+        expect(registry.decodeTokens(line, tags)).toEqual [{value: 'ok, cool',  scopes: ["text.plain", "meta.paragraph.text"]}]
 
         grammar = registry.grammarForScopeName('text.plain')
         {line, tags} = grammar.tokenizeLine(' ok, cool')
 
-        expect(registry.decodeContent(line, tags)).toEqual [
+        expect(registry.decodeTokens(line, tags)).toEqual [
           {value: ' ',  scopes: ["text.plain"]}
           {value: 'ok, cool', scopes: ["text.plain", "meta.paragraph.text"]}
         ]
@@ -206,9 +206,9 @@ describe "Grammar tokenization", ->
         {lines, tags} = grammar.tokenizeLines "#if\ntest\n#endif"
 
         scopes = []
-        line1 = registry.decodeContent(lines[0], tags[0], scopes)
-        line2 = registry.decodeContent(lines[1], tags[1], scopes)
-        line3 = registry.decodeContent(lines[2], tags[2], scopes)
+        line1 = registry.decodeTokens(lines[0], tags[0], scopes)
+        line2 = registry.decodeTokens(lines[1], tags[1], scopes)
+        line3 = registry.decodeTokens(lines[2], tags[2], scopes)
 
         expect(line1.length).toBe 1
         expect(line1[0].value).toEqual "#if"
@@ -225,13 +225,13 @@ describe "Grammar tokenization", ->
         expect(line3[1].scopes).toEqual ["source.test", "all"]
 
         {line, tags} = grammar.tokenizeLine "test"
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens.length).toBe 1
         expect(tokens[0].value).toEqual "test"
         expect(tokens[0].scopes).toEqual ["source.test", "all", "middle"]
 
         {line, tags} = grammar.tokenizeLine " test"
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens.length).toBe 2
         expect(tokens[0].value).toEqual " "
         expect(tokens[0].scopes).toEqual ["source.test", "all"]
@@ -242,7 +242,7 @@ describe "Grammar tokenization", ->
       it "creates tokens without adding a new scope", ->
         grammar = registry.grammarForScopeName('source.ruby')
         {line, tags} = grammar.tokenizeLine('%w|oh \\look|')
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens.length).toBe 5
         expect(tokens[0]).toEqual value: '%w|', scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
@@ -254,7 +254,7 @@ describe "Grammar tokenization", ->
       it "returns tokens based on the beginCaptures, endCaptures and the child scope", ->
         grammar = registry.grammarForScopeName('source.coffee')
         {line, tags} = grammar.tokenizeLine("'''single-quoted heredoc'''")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens.length).toBe 3
 
@@ -269,8 +269,8 @@ describe "Grammar tokenization", ->
           {line: line2, tags: tags2, ruleStack} = grammar.tokenizeLine("heredoc'''", ruleStack)
 
           scopes = []
-          firstTokens = registry.decodeContent(line1, tags1, scopes)
-          secondTokens = registry.decodeContent(line2, tags2, scopes)
+          firstTokens = registry.decodeTokens(line1, tags1, scopes)
+          secondTokens = registry.decodeTokens(line2, tags2, scopes)
 
           expect(firstTokens.length).toBe 2
           expect(secondTokens.length).toBe 2
@@ -285,7 +285,7 @@ describe "Grammar tokenization", ->
         it "returns tokens within the begin/end scope based on the sub-patterns", ->
           grammar = registry.grammarForScopeName('source.coffee')
           {line, tags} = grammar.tokenizeLine('"""heredoc with character escape \\t"""')
-          tokens = registry.decodeContent(line, tags)
+          tokens = registry.decodeTokens(line, tags)
 
           expect(tokens.length).toBe 4
 
@@ -306,11 +306,11 @@ describe "Grammar tokenization", ->
           """
 
           scopes = []
-          lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-          lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
-          lines[2] = registry.decodeContent(lines[2], tags[2], scopes)
-          lines[3] = registry.decodeContent(lines[3], tags[3], scopes)
-          lines[4] = registry.decodeContent(lines[4], tags[4], scopes)
+          lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+          lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
+          lines[2] = registry.decodeTokens(lines[2], tags[2], scopes)
+          lines[3] = registry.decodeTokens(lines[3], tags[3], scopes)
+          lines[4] = registry.decodeTokens(lines[4], tags[4], scopes)
 
           expect(lines[1][2]).toEqual value: "}excentricSyntax", scopes: ['source.apply-end-pattern-last', 'end-pattern-last-env', 'scope', 'excentric']
           expect(lines[4][2]).toEqual value: "}", scopes: ['source.apply-end-pattern-last', 'normal-env', 'scope']
@@ -320,7 +320,7 @@ describe "Grammar tokenization", ->
         it "constructs the end rule based on its back-references to captures in the begin rule", ->
           grammar = registry.grammarForScopeName('source.ruby')
           {line, tags} = grammar.tokenizeLine('%w|oh|,')
-          tokens = registry.decodeContent(line, tags)
+          tokens = registry.decodeTokens(line, tags)
 
           expect(tokens.length).toBe 4
           expect(tokens[0]).toEqual value: '%w|',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
@@ -331,7 +331,7 @@ describe "Grammar tokenization", ->
         it "allows the rule containing that end pattern to be pushed to the stack multiple times", ->
           grammar = registry.grammarForScopeName('source.ruby')
           {line, tags} = grammar.tokenizeLine('%Q+matz had some #{%Q-crazy ideas-} for ruby syntax+ # damn.')
-          tokens = registry.decodeContent(line, tags)
+          tokens = registry.decodeTokens(line, tags)
 
           expect(tokens[0]).toEqual value: '%Q+', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby","punctuation.definition.string.begin.ruby"]
           expect(tokens[1]).toEqual value: 'matz had some ', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby"]
@@ -354,7 +354,7 @@ describe "Grammar tokenization", ->
 
             grammar = registry.grammarForScopeName('text.html.ruby')
             {line, tags} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
-            tokens = registry.decodeContent(line, tags)
+            tokens = registry.decodeTokens(line, tags)
 
             expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
             expect(tokens[1]).toEqual value: 'div', scopes: ["text.html.ruby","meta.tag.block.any.html","entity.name.tag.block.any.html"]
@@ -389,13 +389,13 @@ describe "Grammar tokenization", ->
             grammar.onDidUpdate grammarUpdatedHandler
 
             {line, tags} = grammar.tokenizeLine("<div class='name'><% <<-SQL select * from users;")
-            tokens = registry.decodeContent(line, tags)
+            tokens = registry.decodeTokens(line, tags)
             expect(tokens[12].value).toBe " select * from users;"
 
             loadGrammarSync('sql.json')
             expect(grammarUpdatedHandler).toHaveBeenCalled()
             {line, tags} = grammar.tokenizeLine("<div class='name'><% <<-SQL select * from users;")
-            tokens = registry.decodeContent(line, tags)
+            tokens = registry.decodeTokens(line, tags)
             expect(tokens[12].value).toBe " "
             expect(tokens[13].value).toBe "select"
 
@@ -407,7 +407,7 @@ describe "Grammar tokenization", ->
 
             grammar = registry.grammarForScopeName('text.html.ruby')
             {line, tags} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
-            tokens = registry.decodeContent(line, tags)
+            tokens = registry.decodeTokens(line, tags)
             expect(tokens[0]).toEqual value: "<div class='name'>", scopes: ["text.html.ruby"]
             expect(tokens[1]).toEqual value: '<%=', scopes: ["text.html.ruby","source.ruby.rails.embedded.html","punctuation.section.embedded.ruby"]
             expect(tokens[2]).toEqual value: ' ', scopes: ["text.html.ruby","source.ruby.rails.embedded.html"]
@@ -415,7 +415,7 @@ describe "Grammar tokenization", ->
 
             loadGrammarSync('html.json')
             {line, tags} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
-            tokens = registry.decodeContent(line, tags)
+            tokens = registry.decodeTokens(line, tags)
             expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
             expect(tokens[1]).toEqual value: 'div', scopes: ["text.html.ruby","meta.tag.block.any.html","entity.name.tag.block.any.html"]
             expect(tokens[2]).toEqual value: ' ', scopes: ["text.html.ruby","meta.tag.block.any.html"]
@@ -431,7 +431,7 @@ describe "Grammar tokenization", ->
     it "can parse a grammar with newline characters in its regular expressions (regression)", ->
       grammar = loadGrammarSync('imaginary.cson')
       {line, tags, ruleStack} = grammar.tokenizeLine("// a singleLineComment")
-      tokens = registry.decodeContent(line, tags)
+      tokens = registry.decodeTokens(line, tags)
       expect(ruleStack.length).toBe 1
       expect(ruleStack[0].scopeName).toBe "source.imaginaryLanguage"
 
@@ -444,8 +444,8 @@ describe "Grammar tokenization", ->
       grammar = loadGrammarSync('multiline.cson')
       {lines, tags} = grammar.tokenizeLines('Xy\\\nzX')
       scopes = []
-      lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-      lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
+      lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+      lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
 
       # Line 0
       expect(lines[0][0]).toEqual
@@ -486,12 +486,12 @@ describe "Grammar tokenization", ->
 
       it "correctly parses a method. (regression)", ->
         {line, tags, ruleStack} = grammar.tokenizeLine("if(1){m()}")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens[5]).toEqual value: "m", scopes: ["source.c", "meta.block.c", "meta.function-call.c", "support.function.any-method.c"]
 
       it "correctly parses nested blocks. (regression)", ->
         {line, tags, ruleStack} = grammar.tokenizeLine("if(1){if(1){m()}}")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens[5]).toEqual value: "if", scopes: ["source.c", "meta.block.c", "keyword.control.c"]
         expect(tokens[10]).toEqual value: "m", scopes: ["source.c", "meta.block.c", "meta.block.c", "meta.function-call.c", "support.function.any-method.c"]
 
@@ -500,7 +500,7 @@ describe "Grammar tokenization", ->
         spyOn(console, 'error')
         grammar = loadGrammarSync('infinite-loop.cson')
         {line, tags} = grammar.tokenizeLine("abc")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens[0].value).toBe "a"
         expect(tokens[1].value).toBe "bc"
         expect(console.error).toHaveBeenCalled()
@@ -510,7 +510,7 @@ describe "Grammar tokenization", ->
         loadGrammarSync('scss.json')
         grammar = registry.grammarForScopeName('source.css.scss')
         {line, tags} = grammar.tokenizeLine("@mixin x() { -moz-selector: whatever; }")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens[9]).toEqual value: "-moz-selector", scopes: ["source.css.scss", "meta.property-list.scss", "meta.property-name.scss"]
 
     describe "when a line has more tokens than `maxTokensPerLine`", ->
@@ -519,7 +519,7 @@ describe "Grammar tokenization", ->
         originalRuleStack = grammar.tokenizeLine('').ruleStack
         spyOn(grammar, 'getMaxTokensPerLine').andCallFake -> 5
         {line, tags, ruleStack} = grammar.tokenizeLine("var x = /[a-z]/;", originalRuleStack)
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens.length).toBe 6
         expect(tokens[5].value).toBe "[a-z]/;"
         expect(ruleStack).toEqual originalRuleStack
@@ -529,7 +529,7 @@ describe "Grammar tokenization", ->
       it "matches the patterns and includes the scope specified as the pattern's match name", ->
         grammar = registry.grammarForScopeName('text.html.php')
         {line, tags} = grammar.tokenizeLine("<?php public final function meth() {} ?>")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens[2].value).toBe "public"
         expect(tokens[2].scopes).toEqual ["text.html.php", "meta.embedded.line.php", "source.php", "meta.function.php", "storage.modifier.php"]
@@ -549,7 +549,7 @@ describe "Grammar tokenization", ->
       it "ignores child captures of a capture with patterns", ->
         grammar = loadGrammarSync('nested-captures.cson')
         {line, tags} = grammar.tokenizeLine("ab")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens[0].value).toBe "ab"
         expect(tokens[0].scopes).toEqual ["nested", "text", "a"]
@@ -558,7 +558,7 @@ describe "Grammar tokenization", ->
       it "correctly includes the injected patterns when tokenizing", ->
         grammar = registry.grammarForScopeName('text.html.php')
         {line, tags} = grammar.tokenizeLine("<div><?php function hello() {} ?></div>")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens[3].value).toBe "<?php"
         expect(tokens[3].scopes).toEqual ["text.html.php", "meta.embedded.line.php", "punctuation.section.embedded.begin.php"]
@@ -585,7 +585,7 @@ describe "Grammar tokenization", ->
       it "replaces the group number with the matched captured text", ->
         grammar = loadGrammarSync('hyperlink.json')
         {line, tags} = grammar.tokenizeLine("https://github.com")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens[0].scopes).toEqual ["text.hyperlink", "markup.underline.link.https.hyperlink"]
 
     describe "when the grammar has an injection selector", ->
@@ -593,7 +593,7 @@ describe "Grammar tokenization", ->
         loadGrammarSync('hyperlink.json')
         grammar = registry.grammarForScopeName("source.js")
         {line, tags} = grammar.tokenizeLine("var i; // http://github.com")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens[0].value).toBe "var"
         expect(tokens[0].scopes).toEqual ["source.js", "storage.modifier.js"]
@@ -605,7 +605,7 @@ describe "Grammar tokenization", ->
       it "tokenizes the entire line using the rule", ->
         grammar = loadGrammarSync('forever.cson')
         {line, tags} = grammar.tokenizeLine("forever and ever")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens.length).toBe 1
         expect(tokens[0].value).toBe "forever and ever"
@@ -616,7 +616,7 @@ describe "Grammar tokenization", ->
         loadGrammarSync('todo.json')
         grammar = registry.grammarForScopeName('source.ruby')
         {line, tags} = grammar.tokenizeLine "# TODO be nicer"
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens[2].value).toEqual "TODO"
         expect(tokens[2].scopes).toEqual ["source.ruby", "comment.line.number-sign.ruby", "storage.type.class.todo"]
@@ -626,13 +626,13 @@ describe "Grammar tokenization", ->
         loadGrammarSync('makefile.json')
         grammar = registry.grammarForScopeName('source.makefile')
         {line, tags} = grammar.tokenizeLine("ifeq")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens.length).toBe 1
         expect(tokens[0].value).toEqual "ifeq"
         expect(tokens[0].scopes).toEqual ["source.makefile", "meta.scope.conditional.makefile", "keyword.control.ifeq.makefile"]
 
         {line, tags} = grammar.tokenizeLine("ifeq (")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens.length).toBe 2
         expect(tokens[0].value).toEqual "ifeq"
         expect(tokens[0].scopes).toEqual ["source.makefile", "meta.scope.conditional.makefile", "keyword.control.ifeq.makefile"]
@@ -643,7 +643,7 @@ describe "Grammar tokenization", ->
         loadGrammarSync('makefile.json')
         grammar = registry.grammarForScopeName('source.makefile')
         {line, tags}  = grammar.tokenizeLine(".PHONY:")
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         expect(tokens.length).toBe 2
         expect(tokens[0].scopes).toEqual ["source.makefile", "meta.scope.target.makefile", "support.function.target.PHONY.makefile"]
         expect(tokens[0].value).toEqual ".PHONY"
@@ -659,8 +659,8 @@ describe "Grammar tokenization", ->
           # Please enter the commit message for your changes. Lines starting
         """
         scopes = []
-        lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-        lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
+        lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+        lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
 
       it "correctly parses a long line", ->
         tokens = lines[0]
@@ -681,8 +681,8 @@ describe "Grammar tokenization", ->
           #include "b.h"
         """
         scopes = []
-        lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-        lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
+        lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+        lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
 
       it "correctly parses the first include line", ->
         tokens = lines[0]
@@ -707,9 +707,9 @@ describe "Grammar tokenization", ->
           }
         """
         scopes = []
-        lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-        lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
-        lines[2] = registry.decodeContent(lines[2], tags[2], scopes)
+        lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+        lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
+        lines[2] = registry.decodeTokens(lines[2], tags[2], scopes)
 
       it "doesn't loop infinitely (regression)", ->
         expect(_.pluck(lines[0], 'value').join('')).toBe 'a = {'
@@ -729,9 +729,9 @@ describe "Grammar tokenization", ->
           }
         """
         scopes = []
-        lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-        lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
-        lines[2] = registry.decodeContent(lines[2], tags[2], scopes)
+        lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+        lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
+        lines[2] = registry.decodeTokens(lines[2], tags[2], scopes)
 
       it "correctly parses variable type when it is a built-in Cocoa class", ->
         tokens = lines[1]
@@ -761,9 +761,9 @@ describe "Grammar tokenization", ->
           }
         """
         scopes = []
-        lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-        lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
-        lines[2] = registry.decodeContent(lines[2], tags[2], scopes)
+        lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+        lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
+        lines[2] = registry.decodeTokens(lines[2], tags[2], scopes)
 
         tokens = lines[1]
         expect(tokens[0].scopes).toEqual ["source.java", "comment.line.double-slash.java", "punctuation.definition.comment.java"]
@@ -773,7 +773,7 @@ describe "Grammar tokenization", ->
 
       it "correctly parses nested method calls", ->
         {line, tags} = grammar.tokenizeLine('a(b(new Object[0]));')
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
         lastToken = _.last(tokens)
         expect(lastToken.scopes).toEqual ['source.java', 'punctuation.terminator.java']
         expect(lastToken.value).toEqual ';'
@@ -782,7 +782,7 @@ describe "Grammar tokenization", ->
       it "correctly parses strings inside tags", ->
         grammar = registry.grammarForScopeName('text.html.erb')
         {line, tags} = grammar.tokenizeLine '<% page_title "My Page" %>'
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens[2].value).toEqual '"'
         expect(tokens[2].scopes).toEqual ["text.html.erb", "meta.embedded.line.erb", "source.ruby", "string.quoted.double.ruby", "punctuation.definition.string.begin.ruby"]
@@ -797,7 +797,7 @@ describe "Grammar tokenization", ->
 
         grammar = registry.grammarForScopeName('text.html.erb')
         {line, tags} = grammar.tokenizeLine('<%>')
-        tokens = registry.decodeContent(line, tags)
+        tokens = registry.decodeTokens(line, tags)
 
         expect(tokens.length).toBe 1
         expect(tokens[0].value).toEqual '<%>'
@@ -808,7 +808,7 @@ describe "Grammar tokenization", ->
         it "correctly parses JavaScript strings containing surrogate pair characters", ->
           grammar = registry.grammarForScopeName('source.js')
           {line, tags} = grammar.tokenizeLine "'\uD835\uDF97'"
-          tokens = registry.decodeContent(line, tags)
+          tokens = registry.decodeTokens(line, tags)
 
           expect(tokens.length).toBe 3
           expect(tokens[0].value).toBe "'"
@@ -820,7 +820,7 @@ describe "Grammar tokenization", ->
           loadGrammarSync('json.json')
           grammar = registry.grammarForScopeName('source.json')
           {line, tags} = grammar.tokenizeLine '{"\u2026": 1}'
-          tokens = registry.decodeContent(line, tags)
+          tokens = registry.decodeTokens(line, tags)
 
           expect(tokens.length).toBe 8
           expect(tokens[6].value).toBe '1'
@@ -831,8 +831,8 @@ describe "Grammar tokenization", ->
         grammar = registry.grammarForScopeName('source.python')
         {lines, tags} = grammar.tokenizeLines "import a\nimport b"
         scopes = []
-        lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-        lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
+        lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+        lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
 
         line1 = lines[0]
         expect(line1.length).toBe 3
@@ -870,11 +870,11 @@ describe "Grammar tokenization", ->
             </html>
           """
           scopes = []
-          lines[0] = registry.decodeContent(lines[0], tags[0], scopes)
-          lines[1] = registry.decodeContent(lines[1], tags[1], scopes)
-          lines[2] = registry.decodeContent(lines[2], tags[2], scopes)
-          lines[3] = registry.decodeContent(lines[3], tags[3], scopes)
-          lines[4] = registry.decodeContent(lines[4], tags[4], scopes)
+          lines[0] = registry.decodeTokens(lines[0], tags[0], scopes)
+          lines[1] = registry.decodeTokens(lines[1], tags[1], scopes)
+          lines[2] = registry.decodeTokens(lines[2], tags[2], scopes)
+          lines[3] = registry.decodeTokens(lines[3], tags[3], scopes)
+          lines[4] = registry.decodeTokens(lines[4], tags[4], scopes)
 
 
           line4 = lines[4]
@@ -893,7 +893,7 @@ describe "Grammar tokenization", ->
       loadGrammarSync("loops.json")
       grammar = registry.grammarForScopeName("source.loops")
       {line, tags, ruleStack} = grammar.tokenizeLine('test')
-      tokens = registry.decodeContent(line, tags)
+      tokens = registry.decodeTokens(line, tags)
 
       expect(ruleStack.length).toBe 1
       expect(console.error.callCount).toBe 1

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -229,7 +229,7 @@ class GrammarRegistry
     grammar.path = grammarPath
     grammar
 
-  decodeContent: (lineText, tags, scopeTags = [], fn) ->
+  decodeTokens: (lineText, tags, scopeTags = [], fn) ->
     offset = 0
     scopeNames = scopeTags.map (tag) => @scopeForId(tag)
 

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -229,18 +229,20 @@ class GrammarRegistry
     grammar.path = grammarPath
     grammar
 
-  decodeContent: (lineText, tags, scopeTags = []) ->
+  decodeContent: (lineText, tags, scopeTags = [], fn) ->
     offset = 0
     scopeNames = scopeTags.map (tag) => @scopeForId(tag)
 
     tokens = []
-    for tag in tags
+    for tag, index in tags
       # positive numbers indicate string content with length equaling the number
       if tag >= 0
-        tokens.push({
+        token = {
           value: lineText.substring(offset, offset + tag)
           scopes: scopeNames.slice()
-        })
+        }
+        token = fn(token, index) if fn?
+        tokens.push(token)
         offset += tag
 
       # odd negative numbers are begin scope tags

--- a/src/rule.coffee
+++ b/src/rule.coffee
@@ -83,15 +83,15 @@ class Rule
       @normalizeCaptureIndices(lineWithNewline, result.captureIndices)
       result
 
-  getNextContent: (ruleStack, line, position, firstLine) ->
+  getNextTags: (ruleStack, line, position, firstLine) ->
     result = @findNextMatch(ruleStack, line, position, firstLine)
     return null unless result?
 
     {index, captureIndices, scanner} = result
     [firstCapture] = captureIndices
     endPatternMatch = @endPattern is scanner.patterns[index]
-    nextContent = scanner.handleMatch(result, ruleStack, line, this, endPatternMatch)
-    {nextContent, contentStart: firstCapture.start, contentEnd: firstCapture.end}
+    nextTags = scanner.handleMatch(result, ruleStack, line, this, endPatternMatch)
+    {nextTags, tagsStart: firstCapture.start, tagsEnd: firstCapture.end}
 
   getRuleToPush: (line, beginPatternCaptureIndices) ->
     if @endPattern.hasBackReferences

--- a/src/rule.coffee
+++ b/src/rule.coffee
@@ -83,15 +83,15 @@ class Rule
       @normalizeCaptureIndices(lineWithNewline, result.captureIndices)
       result
 
-  getNextTokens: (ruleStack, line, position, firstLine) ->
+  getNextContent: (ruleStack, line, position, firstLine) ->
     result = @findNextMatch(ruleStack, line, position, firstLine)
     return null unless result?
 
     {index, captureIndices, scanner} = result
     [firstCapture] = captureIndices
     endPatternMatch = @endPattern is scanner.patterns[index]
-    nextTokens = scanner.handleMatch(result, ruleStack, line, this, endPatternMatch)
-    {nextTokens, tokensStartPosition: firstCapture.start, tokensEndPosition: firstCapture.end}
+    nextContent = scanner.handleMatch(result, ruleStack, line, this, endPatternMatch)
+    {nextContent, contentStart: firstCapture.start, contentEnd: firstCapture.end}
 
   getRuleToPush: (line, beginPatternCaptureIndices) ->
     if @endPattern.hasBackReferences


### PR DESCRIPTION
Token objects with arrays of scopes were consuming too much memory in Atom. This representation returns an array of integer `tags` for each tokenized line instead. Negative integers represent the start or end of scopes, and non-negative integers represent one or more characters from the parsed string.

Odd negative integers represent scopes starting at that location of the line. Even negative integers represent the end of the scope corresponding to the preceding odd integer. `GrammarRegistry::scopeForId` can be used to retrieve scope names for odd integers. For even integers, you need to add 1 before calling it.