### PR TITLE
Fix issue with infinite loop due to the rule that doesn't consume and gets pushed and popped

### DIFF
--- a/spec/fixtures/infinite-loop-rules.json
+++ b/spec/fixtures/infinite-loop-rules.json
@@ -1,0 +1,16 @@
+{
+  "name": "infinite-loop-rules-grammar",
+  "scopeName": "source.infinite-loop-rules",
+  "patterns": [
+    {
+      "include": "#push-pop-rule"
+    }
+  ],
+  "repository": {
+    "push-pop-rule": {
+      "begin": "(?=\\<)",
+      "end": "(?<=\\})",
+      "name": "bad.rule"
+    }
+  }
+}

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -492,6 +492,18 @@ describe "Grammar tokenization", ->
         expect(scopes).toEqual [registry.startIdForScope(grammar.scopeName)]
         expect(console.error).toHaveBeenCalled()
 
+    describe "when the grammar can infinitely loop through non-consuming rule over a line", ->
+      it "aborts tokenization", ->
+        spyOn(console, 'error')
+        grammar = loadGrammarSync('infinite-loop-rules.json')
+        {line, tags} = grammar.tokenizeLine("}<")
+        scopes = []
+        tokens = registry.decodeTokens(line, tags, scopes)
+        expect(tokens[0].value).toBe "}"
+        expect(tokens[1].value).toBe "<"
+        expect(scopes).toEqual [registry.startIdForScope(grammar.scopeName)]
+        expect(console.error).toHaveBeenCalled()
+
     describe "when a grammar has a pattern that has back references in the match value", ->
       it "does not special handle the back references and instead allows oniguruma to resolve them", ->
         loadGrammarSync('scss.json')

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -121,6 +121,8 @@ class Grammar
     initialRuleStackLength = ruleStack.length
     position = 0
     tokenCount = 0
+    # initial rules are considered to have advanced to allow them to pop
+    currentRuleHasAdvanced = true
 
     loop
       previousRuleStackLength = ruleStack.length
@@ -155,7 +157,12 @@ class Grammar
         break
 
       if position is previousPosition
-        if ruleStack.length is previousRuleStackLength
+        if ruleStack.length < previousRuleStackLength # Stack size decreased (rule poped) with zero length match
+          if !currentRuleHasAdvanced
+            console.error("Skipping line because rule loops at column #{position} of line '#{line}'", _.clone(ruleStack))
+            tags.push(line.length - position)
+            break
+        else if ruleStack.length is previousRuleStackLength
           console.error("Popping rule because it loops at column #{position} of line '#{line}'", _.clone(ruleStack))
           if ruleStack.length > 1
             {scopeName, contentScopeName} = ruleStack.pop()
@@ -167,6 +174,9 @@ class Grammar
             break
         else if ruleStack.length > previousRuleStackLength # Stack size increased with zero length match
           [{rule: penultimateRule}, {rule: lastRule}] = ruleStack[-2..]
+
+          # Don't allow the current rule to pop until it has consumed something
+          currentRuleHasAdvanced = false
 
           # Same exact rule was pushed but position wasn't advanced
           if lastRule? and lastRule is penultimateRule
@@ -183,6 +193,8 @@ class Grammar
               tags.pop() # also pop the duplicated start scope if it was pushed
             tags.push(line.length - position)
             break
+      else
+        currentRuleHasAdvanced = true
 
     rule.clearAnchorPosition() for {rule} in ruleStack
 


### PR DESCRIPTION
We have found in the wild a grammar that triggers an infinite loop in tokenization. The problem was due to a rule that would enter without advancing the input and would leave also without advancing the input (see `infinite-loop-rules.json` for a simplified example).

Thinking about it, I think the `while(true)` loop of `grammar.tokenizeLine` can end up in an infinite loop with the following rule stack patterns:
* ABC, ABC, ABC, ... [this was already protected against]
* ABC, ABCC, ABCCC, ... [this was already protected against]
* ABC, AB, ABC, AB, ... [<---this is the one being addressed in this PR]
* ABC, ABCD, ABCDE, ABCDEC, ABCDECD, ABCDECDE ...  [<---this one is not yet addressed]

The change I propose for the third looping pattern is to keep track in a boolean (`currentRuleHasAdvanced`) if the last pushed rule has advanced whatsoever, and if it did not, then skip the entire line if the rule is being popped.

For the fourth looping pattern, I'm afraid I don't have enough TMbundle knowledge to produce a simple grammar demonstrating it, nor do I understand `grammar.tokenizeLine` sufficiently to propose a fix.
