### PR TITLE
Allow including repository patterns from other grammars

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -32,7 +32,7 @@ module.exports = (grunt) ->
 
     shell:
       test:
-        command: 'node --harmony_collections node_modules/.bin/jasmine-focused --coffee --captureExceptions spec'
+        command: 'node node_modules/.bin/jasmine-focused --coffee --captureExceptions spec'
         options:
           stdout: true
           stderr: true

--- a/spec/fixtures/include-external-repository-rule.cson
+++ b/spec/fixtures/include-external-repository-rule.cson
@@ -1,0 +1,4 @@
+scopeName: 'test.include-external-repository-rule'
+patterns: [
+  { include: 'source.python#builtin_functions' }
+]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -387,6 +387,13 @@ describe "Grammar tokenization", ->
             expect(tokens[12].value).toBe " "
             expect(tokens[13].value).toBe "select"
 
+          it "supports including repository rules from the other grammar", ->
+            loadGrammarSync('include-external-repository-rule.cson')
+            grammar = registry.grammarForScopeName('test.include-external-repository-rule')
+            {line, tags} = grammar.tokenizeLine('enumerate')
+            tokens = registry.decodeTokens(line, tags)
+            expect(tokens[0]).toEqual value: 'enumerate', scopes: ["test.include-external-repository-rule", "support.function.builtin.python"]
+
         describe "when a grammar matching the desired scope is unavailable", ->
           it "updates the grammar if a matching grammar is added later", ->
             registry.removeGrammarForScopeName('text.html.basic')

--- a/src/pattern.coffee
+++ b/src/pattern.coffee
@@ -102,6 +102,12 @@ class Pattern
     else if name is "$base"
       baseGrammar.getInitialRule()
     else
+      hashIndex = name.indexOf("#")
+      if hashIndex isnt -1
+        grammarName = name[0..hashIndex-1]
+        @grammar.addIncludedGrammarScope(grammarName)
+        grammar = @registry.grammarForScopeName(grammarName)
+        return grammar?.getRepository()?[name[hashIndex+1..]]
       @grammar.addIncludedGrammarScope(name)
       @registry.grammarForScopeName(name)?.getInitialRule()
 


### PR DESCRIPTION
TextMate 2 supports the "grammarB#rule" syntax for including a pattern from grammarB's "repository" section. (e.g. https://github.com/textmate/bundle-development.tmbundle/blob/master/Syntaxes/Language%20Grammar.tmLanguage#L1631)

This adds similar functionality to first-mate.