### PR TITLE
Remove grammar-selection functionality

### DIFF
--- a/spec/grammar-registry-spec.coffee
+++ b/spec/grammar-registry-spec.coffee
@@ -7,71 +7,6 @@ describe "GrammarRegistry", ->
   loadGrammarSync = (name) ->
     registry.loadGrammarSync(path.join(__dirname, 'fixtures', name))
 
-  describe "grammar overrides", ->
-    it "stores the override scope name for a path", ->
-      registry = new GrammarRegistry()
-
-      expect(registry.grammarOverrideForPath('foo.js.txt')).toBeUndefined()
-      expect(registry.grammarOverrideForPath('bar.js.txt')).toBeUndefined()
-
-      registry.setGrammarOverrideForPath('foo.js.txt', 'source.js')
-      expect(registry.grammarOverrideForPath('foo.js.txt')).toBe 'source.js'
-
-      registry.setGrammarOverrideForPath('bar.js.txt', 'source.coffee')
-      expect(registry.grammarOverrideForPath('bar.js.txt')).toBe 'source.coffee'
-
-      registry.clearGrammarOverrideForPath('foo.js.txt')
-      expect(registry.grammarOverrideForPath('foo.js.txt')).toBeUndefined()
-      expect(registry.grammarOverrideForPath('bar.js.txt')).toBe 'source.coffee'
-
-      registry.clearGrammarOverrides()
-      expect(registry.grammarOverrideForPath('bar.js.txt')).toBeUndefined()
-
-      registry.setGrammarOverrideForPath('', 'source.coffee')
-      expect(registry.grammarOverrideForPath('')).toBeUndefined()
-
-      registry.setGrammarOverrideForPath(null, 'source.coffee')
-      expect(registry.grammarOverrideForPath(null)).toBeUndefined()
-
-      registry.setGrammarOverrideForPath(undefined, 'source.coffee')
-      expect(registry.grammarOverrideForPath(undefined)).toBeUndefined()
-
-  describe "::selectGrammar", ->
-    it "always returns a grammar", ->
-      registry = new GrammarRegistry()
-      expect(registry.selectGrammar().scopeName).toBe 'text.plain.null-grammar'
-
-    it "selects the text.plain grammar over the null grammar", ->
-      registry = new GrammarRegistry()
-      loadGrammarSync('text.json')
-
-      expect(registry.selectGrammar('test.txt').scopeName).toBe 'text.plain'
-
-    it "selects a grammar based on the file path case insensitively", ->
-      registry = new GrammarRegistry()
-      loadGrammarSync('javascript.json')
-      loadGrammarSync('coffee-script.json')
-
-      expect(registry.selectGrammar('/tmp/source.coffee').scopeName).toBe 'source.coffee'
-      expect(registry.selectGrammar('/tmp/source.COFFEE').scopeName).toBe 'source.coffee'
-
-    describe "on Windows", ->
-      originalPlatform = null
-
-      beforeEach ->
-        originalPlatform = process.platform
-        Object.defineProperty process, 'platform', value: 'win32'
-
-      afterEach ->
-        Object.defineProperty process, 'platform', value: originalPlatform
-
-      it "normalizes back slashes to forward slashes when matching the fileTypes", ->
-        registry = new GrammarRegistry()
-        loadGrammarSync('file-types-with-slashes.json')
-
-        expect(registry.selectGrammar('C:\\.atom\\hello').scopeName).toBe 'fileTypes.withSlashes'
-        expect(registry.selectGrammar('/a/b/c/.atom/hello').scopeName).toBe 'fileTypes.withSlashes'
-
   describe "when the grammar has no scope name", ->
     it "throws an error", ->
       grammarPath = path.join(__dirname, 'fixtures', 'no-scope-name.json')
@@ -92,7 +27,7 @@ describe "GrammarRegistry", ->
       registry = new GrammarRegistry(maxTokensPerLine: 2)
       loadGrammarSync('json.json')
 
-      grammar = registry.selectGrammar('test.json')
+      grammar = registry.grammarForScopeName('source.json')
       expect(grammar.maxTokensPerLine).toBe 2
 
       {line, tags} = grammar.tokenizeLine("{ }")

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -24,15 +24,6 @@ describe "Grammar tokenization", ->
     loadGrammarSync('python-regex.cson')
 
   describe "when the registry is empty", ->
-    it "tokenizes using the null grammar", ->
-      emptyRegistry = new GrammarRegistry()
-      grammar = emptyRegistry.selectGrammar('foo.js', '')
-      {line, tags} = grammar.tokenizeLine('a = 1;')
-      tokens = emptyRegistry.decodeTokens(line, tags)
-      expect(tokens.length).toBe 1
-      expect(tokens[0].value).toBe 'a = 1;'
-      expect(tokens[0].scopes).toEqual ['text.plain.null-grammar']
-
     it "allows injections into the null grammar", ->
       registry = new GrammarRegistry()
       loadGrammarSync('hyperlink.json')

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -159,52 +159,6 @@ class GrammarRegistry
 
     undefined
 
-  # Public: Get the grammar override for the given file path.
-  #
-  # * `filePath` A {String} file path.
-  #
-  # Returns a {Grammar} or undefined.
-  grammarOverrideForPath: (filePath) ->
-    @grammarOverridesByPath[filePath]
-
-  # Public: Set the grammar override for the given file path.
-  #
-  # * `filePath` A non-empty {String} file path.
-  # * `scopeName` A {String} such as `"source.js"`.
-  #
-  # Returns a {Grammar} or undefined.
-  setGrammarOverrideForPath: (filePath, scopeName) ->
-    if filePath
-      @grammarOverridesByPath[filePath] = scopeName
-
-  # Public: Remove the grammar override for the given file path.
-  #
-  # * `filePath` A {String} file path.
-  #
-  # Returns undefined.
-  clearGrammarOverrideForPath: (filePath) ->
-    delete @grammarOverridesByPath[filePath]
-    undefined
-
-  # Public: Remove all grammar overrides.
-  #
-  # Returns undefined.
-  clearGrammarOverrides: ->
-    @grammarOverridesByPath = {}
-    undefined
-
-  # Public: Select a grammar for the given file path and file contents.
-  #
-  # This picks the best match by checking the file path and contents against
-  # each grammar.
-  #
-  # * `filePath` A {String} file path.
-  # * `fileContents` A {String} of text for the file path.
-  #
-  # Returns a {Grammar}, never null.
-  selectGrammar: (filePath, fileContents) ->
-    _.max @grammars, (grammar) -> grammar.getScore(filePath, fileContents)
-
   startIdForScope: (scope) ->
     unless id = @idsByScope[scope]
       id = @scopeIdCounter


### PR DESCRIPTION
Refs https://github.com/atom/atom/pull/8144

This code was previously partially-overridden in Atom. Now it is totally overridden.