### PR TITLE
bumping oniguruma to version 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "event-kit": "^1.0.0",
     "fs-plus": "^2",
     "grim": "^1.2.1",
-    "oniguruma": "^4.0.0",
+    "oniguruma": "^5.1.0",
     "season": "^5.0.2",
     "underscore-plus": "^1"
   },


### PR DESCRIPTION
this fixes a big memory leak. the js api did not change even though this is a major bump.