### PR TITLE
Add breaking test for emoji in JavaScript strings

### DIFF
--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -800,6 +800,31 @@ describe "Grammar tokenization", ->
           expect(tokens[6].value).toBe '1'
           expect(tokens[6].scopes).toEqual ["source.json", "meta.structure.dictionary.json", "meta.structure.dictionary.value.json", "constant.numeric.json"]
 
+      describe "when the line contains emoji characters", ->
+
+        it "correctly terminates quotes & parses tokens starting after them", ->
+          grammar = registry.grammarForScopeName('source.js')
+
+          withoutEmoji = grammar.tokenizeLine "var emoji = 'http://a'; var after;"
+          withoutEmojiTokens = registry.decodeTokens(withoutEmoji.line, withoutEmoji.tags)
+
+          withEmoji = grammar.tokenizeLine "var emoji = '💻 http://a'; var after;"
+          withEmojiTokens = registry.decodeTokens(withEmoji.line, withEmoji.tags)
+
+          # ignoring this value (the string containing the emoji), they should be identical
+          withoutEmojiTokens[5].value = 'ABC'
+          withEmojiTokens[5].value = 'ABC'
+
+          expect(withEmojiTokens).toEqual(withoutEmojiTokens)
+
+          expect(withoutEmojiTokens.length).toBe 12
+          expect(withoutEmojiTokens[7].value).toBe ';'
+          expect(withoutEmojiTokens[7].scopes).toEqual [ 'source.js', 'punctuation.terminator.statement.js' ]
+
+          expect(withEmojiTokens.length).toBe 12
+          expect(withEmojiTokens[7].value).toBe ';'
+          expect(withEmojiTokens[7].scopes).toEqual [ 'source.js', 'punctuation.terminator.statement.js' ]
+
     describe "python", ->
       it "parses import blocks correctly", ->
         grammar = registry.grammarForScopeName('source.python')


### PR DESCRIPTION
This PR adds a test for the correct termination of strings containing emoji (https://github.com/atom/atom/issues/9153). The difference between the 2 outputs isn't that much but hopefully it will help!

Diff of the expected (`withoutEmojiTokens`) vs actual (`withEmojiTokens`) output:
![image](https://cloud.githubusercontent.com/assets/2421069/10609231/946a0e5a-773a-11e5-97c0-a52dc45efe53.png)


```js
var withoutEmojiTokens = [ { value: 'var', scopes: [ 'source.js', 'storage.modifier.js' ] },
  { value: ' emoji ', scopes: [ 'source.js' ] },
  { value: '=', scopes: [ 'source.js', 'keyword.operator.js' ] },
  { value: ' ', scopes: [ 'source.js' ] },
  { value: '\'',
    scopes:
     [ 'source.js',
       'string.quoted.single.js',
       'punctuation.definition.string.begin.js' ] },
  { value: 'http://a',
    scopes: [ 'source.js', 'string.quoted.single.js' ] },
  { value: '\'',
    scopes:
     [ 'source.js',
       'string.quoted.single.js',
       'punctuation.definition.string.end.js' ] },
  { value: ';', scopes: [ 'source.js', 'punctuation.terminator.statement.js' ] },
  { value: ' ', scopes: [ 'source.js' ] },
  { value: 'var', scopes: [ 'source.js', 'storage.modifier.js' ] },
  { value: ' after', scopes: [ 'source.js' ] },
  { value: ';',
    scopes: [ 'source.js', 'punctuation.terminator.statement.js' ] } ]
```


```js
var withEmojiTokens = [ { value: 'var', scopes: [ 'source.js', 'storage.modifier.js' ] },
  { value: ' emoji ', scopes: [ 'source.js' ] },
  { value: '=', scopes: [ 'source.js', 'keyword.operator.js' ] },
  { value: ' ', scopes: [ 'source.js' ] },
  { value: '\'',
    scopes:
     [ 'source.js',
       'string.quoted.single.js',
       'punctuation.definition.string.begin.js' ] },
  { value: '💻 http://a',
    scopes: [ 'source.js', 'string.quoted.single.js' ] },
  { value: '\'',
    scopes:
     [ 'source.js',
       'string.quoted.single.js',
       'punctuation.definition.string.end.js' ] },
  { value: '; ', scopes: [ 'source.js' ] },
  { value: 'var', scopes: [ 'source.js', 'storage.modifier.js' ] },
  { value: ' after', scopes: [ 'source.js' ] },
  { value: ';',
    scopes: [ 'source.js', 'punctuation.terminator.statement.js' ] } ]
```