### PR TITLE
Add maxLineLength option to Grammar to only tokenize the first n characters of a line

### DIFF
--- a/spec/grammar-registry-spec.coffee
+++ b/spec/grammar-registry-spec.coffee
@@ -33,3 +33,15 @@ describe "GrammarRegistry", ->
       {line, tags} = grammar.tokenizeLine("{ }")
       tokens = registry.decodeTokens(line, tags)
       expect(tokens.length).toBe 2
+
+  describe "maxLineLength option", ->
+    it "should set the value on each created grammar and doesn't tokenize more than that many characters of the line", ->
+      registry = new GrammarRegistry(maxLineLength: 1)
+      loadGrammarSync('json.json')
+
+      grammar = registry.grammarForScopeName('source.json')
+      expect(grammar.maxLineLength).toBe 1
+
+      {line, tags} = grammar.tokenizeLine("{ \"test\":\"object\" }")
+      tokens = registry.decodeTokens(line, tags)
+      expect(tokens.length).toBe 2

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -518,6 +518,20 @@ describe "Grammar tokenization", ->
         expect(ruleStack).not.toBe originalRuleStack
         expect(scopes.length).toBe 0
 
+    describe "when the line is longer than the maxLineLength", ->
+      it "creates a final token with the text between the maxLineLength and the end of the line and resets the ruleStack to the starting stack", ->
+        grammar = registry.grammarForScopeName('source.js')
+        originalRuleStack = grammar.tokenizeLine('').ruleStack
+        spyOn(grammar, 'getMaxLineLength').andCallFake -> 9
+        {line, tags, ruleStack} = grammar.tokenizeLine("var x = /[a-z]/;", originalRuleStack)
+        scopes = []
+        tokens = registry.decodeTokens(line, tags, scopes)
+        expect(tokens.length).toBe 6
+        expect(tokens[5].value).toBe "[a-z]/;"
+        expect(ruleStack).toEqual originalRuleStack
+        expect(ruleStack).not.toBe originalRuleStack
+        expect(scopes.length).toBe 0
+
     describe "when a grammar has a capture with patterns", ->
       it "matches the patterns and includes the scope specified as the pattern's match name", ->
         grammar = registry.grammarForScopeName('text.html.php')

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -11,6 +11,7 @@ module.exports =
 class GrammarRegistry
   constructor: (options={}) ->
     @maxTokensPerLine = options.maxTokensPerLine ? Infinity
+    @maxLineLength = options.maxLineLength ? Infinity
     @nullGrammar = new NullGrammar(this)
     @clear()
 
@@ -187,6 +188,7 @@ class GrammarRegistry
 
   createGrammar: (grammarPath, object) ->
     object.maxTokensPerLine ?= @maxTokensPerLine
+    object.maxLineLength ?= @maxLineLength
     grammar = new Grammar(this, object)
     grammar.path = grammarPath
     grammar


### PR DESCRIPTION
This will allow skipping tokenization of lines that are too long.  This is to prevent hangs on opening files with long lines, https://github.com/atom/atom/issues/979.
