### PR TITLE
Fix scope name resolution

### DIFF
--- a/spec/fixtures/scope-names-with-placeholders.cson
+++ b/spec/fixtures/scope-names-with-placeholders.cson
@@ -1,0 +1,8 @@
+name: 'scope names with placeholders'
+scopeName: 'scope-names-with-placeholders'
+patterns: [
+  {
+    match: '(a) (b)'
+    name: '$1.$2'
+  }
+]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -640,6 +640,15 @@ describe "Grammar tokenization", ->
         expect(tokens[0].scopes).toEqual ["source.makefile", "meta.scope.target.makefile", "support.function.target.PHONY.makefile"]
         expect(tokens[0].value).toEqual ".PHONY"
 
+      it "replaces all occurences of capture index placeholders", ->
+        loadGrammarSync("scope-names-with-placeholders.cson")
+        grammar = registry.grammarForScopeName("scope-names-with-placeholders")
+        {line, tags} = grammar.tokenizeLine("a b")
+        tokens = registry.decodeTokens(line, tags)
+        expect(tokens.length).toBe 1
+        expect(tokens[0].value).toEqual "a b"
+        expect(tokens[0].scopes).toEqual ["scope-names-with-placeholders", "a.b"]
+
   describe "language-specific integration tests", ->
     lines = null
 

--- a/src/pattern.coffee
+++ b/src/pattern.coffee
@@ -1,7 +1,7 @@
 _ = require 'underscore-plus'
 
+AllCustomCaptureIndicesRegex = /\$(\d+)|\${(\d+):\/(downcase|upcase)}/g
 AllDigitsRegex = /\\\d+/g
-CustomCaptureIndexRegex = /\$(\d+)|\${(\d+):\/(downcase|upcase)}/
 DigitRegex = /\\\d+/
 
 module.exports =
@@ -119,7 +119,7 @@ class Pattern
       [this]
 
   resolveScopeName: (scopeName, line, captureIndices) ->
-    resolvedScopeName = scopeName.replace CustomCaptureIndexRegex, (match, index, commandIndex, command) ->
+    resolvedScopeName = scopeName.replace AllCustomCaptureIndicesRegex, (match, index, commandIndex, command) ->
       capture = captureIndices[parseInt(index ? commandIndex)]
       if capture?
         replacement = line.substring(capture.start, capture.end)


### PR DESCRIPTION
Consider this grammar:

```cson
name: 'scope names with placeholders'
scopeName: 'scope-names-with-placeholders'
patterns: [
  {
    match: '(a) (b)'
    name: '$1.$2'
  }
]
```

At the moment tokenizing the string __"a b"__ will result in assigning the scope name `a.$2`.
I expect it to be `a.b`.

This PR fixes scope name resolution routine to substitute __all__ capturing group references in scope name, not the first met one.
