### PR TITLE
Updated package.json to allow first-mate to work in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
   "homepage": "http://atom.github.io/first-mate",
   "dependencies": {
     "emissary": "^1",
-    "event-kit": "^1.0.0",
+    "event-kit": "^2.0.0",
     "fs-plus": "^2",
     "grim": "^1.2.1",
     "oniguruma": "^5.1.2",
+    "onigurumajs": "^1.0.0",
     "season": "^5.0.2",
     "underscore-plus": "^1"
   },
@@ -42,5 +43,12 @@
     "coffee-script": "~1.7.0",
     "grunt-peg": "~1.1.0",
     "grunt-atomdoc": "^1.0.0"
+  },
+  "browser": {
+    "fs-plus": false,
+    "season": false,
+    "grim": false,
+    "emissary": false,
+    "oniguruma": "onigurumajs"
   }
 }


### PR DESCRIPTION
I was able to get `first-mate` to work in the browser without making any code changes and by only modifying the project's `package.json` file.

- Upgraded to `event-kit@2.0.0`
- Added `onigurumajs` as a dependency
- Using the [`browser` override field in the `package.json`](https://github.com/defunctzombie/package-browser-field-spec):
  - Use [onigurumajs](https://github.com/bcoe/onigurumajs) in the browser (instead of `oniguruma` which of course requires native C++ bindings)
  - Disabled `fs-plus`, `season`, `grim` and `emissary` for the browser (all have references to `fs`, a server only module)

Other than upgrading `event-kit` this does not impact any of the code running on the server. All tests are passing.

After these changes I used my JavaScript module bundler to build the browser bundles and `first-mate` worked perfectly for the language grammar files I tried ([language-marko](https://atom.io/packages/language-marko), [language-javascript](https://github.com/atom/language-javascript) and [language-css](https://github.com/atom/language-css)). I also created an adapter that allows any Atom grammar file to be used to apply syntax highlighting in a CodeMirror editor: https://github.com/patrick-steele-idem/codemirror-atom-modes

Please let me know if you have any questions or thoughts. Thanks!