### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ notifications:
     on_failure: change
 
 node_js:
-  - 6
-  - 5
-  - 0.10
+  - node
 
 git:
   depth: 10

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "jasmine-focused": "^1",
-    "grunt-contrib-coffee": "~0.9.0",
+    "grunt-contrib-coffee": "^1.0.0",
     "grunt-cli": "~0.1.8",
     "grunt": "^1.0.1",
     "grunt-shell": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-coffee": "~0.9.0",
     "grunt-cli": "~0.1.8",
     "grunt": "^1.0.1",
-    "grunt-shell": "~0.2.2",
+    "grunt-shell": "^2.0.0",
     "grunt-coffeelint": "^0.0.16",
     "rimraf": "^2.5.4",
     "coffee-script": "~1.7.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jasmine-focused": "^1",
     "grunt-contrib-coffee": "~0.9.0",
     "grunt-cli": "~0.1.8",
-    "grunt": "~0.4.1",
+    "grunt": "^1.0.1",
     "grunt-shell": "~0.2.2",
     "grunt-coffeelint": "^0.0.16",
     "rimraf": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt": "~0.4.1",
     "grunt-shell": "~0.2.2",
     "grunt-coffeelint": "^0.0.16",
-    "rimraf": "~2.1.4",
+    "rimraf": "^2.5.4",
     "coffee-script": "~1.7.0",
     "grunt-peg": "~1.1.0",
     "grunt-atomdoc": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-coffeelint": "^0.0.16",
     "rimraf": "^2.5.4",
     "coffee-script": "~1.7.0",
-    "grunt-peg": "~1.1.0",
+    "grunt-peg": "^2.0.1",
     "grunt-atomdoc": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-shell": "^2.0.0",
     "grunt-coffeelint": "^0.0.16",
     "rimraf": "^2.5.4",
-    "coffee-script": "~1.7.0",
+    "coffee-script": "~1.11.1",
     "grunt-peg": "^2.0.1",
     "grunt-atomdoc": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-cli": "~0.1.8",
     "grunt": "~0.4.1",
     "grunt-shell": "~0.2.2",
-    "grunt-coffeelint": "0.0.6",
+    "grunt-coffeelint": "^0.0.16",
     "rimraf": "~2.1.4",
     "coffee-script": "~1.7.0",
     "grunt-peg": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-shell": "^2.0.0",
     "grunt-coffeelint": "^0.0.16",
     "rimraf": "^2.5.4",
-    "coffee-script": "~1.11.1",
+    "coffee-script": "~1.7.0",
     "grunt-peg": "^2.0.1",
     "grunt-atomdoc": "^1.0.0"
   }

--- a/src/injections.coffee
+++ b/src/injections.coffee
@@ -13,7 +13,7 @@ class Injections
       patterns = []
       for regex in values.patterns
         pattern = @grammar.createPattern(regex)
-        patterns.push(pattern.getIncludedPatterns(grammar, patterns)...)
+        patterns.push(pattern.getIncludedPatterns(@grammar, patterns)...)
       @injections.push
         selector: new ScopeSelector(selector)
         patterns: patterns


### PR DESCRIPTION
Should fix a bunch of warnings regarding graceful-fs<strike> and minimatch</strike>.  Apparently even with the updated dependencies, none of them are using a recent version of minimatch.
