### PR TITLE
Update `scopeSelector.toCss()` to return prefixed syntax selectors

### DIFF
--- a/spec/scope-selector-spec.coffee
+++ b/spec/scope-selector-spec.coffee
@@ -74,13 +74,13 @@ describe "ScopeSelector", ->
 
   describe ".toCssSelector()", ->
     it "converts the TextMate scope selector to a CSS selector", ->
-      expect(new ScopeSelector('a b c').toCssSelector()).toBe '.a .b .c'
-      expect(new ScopeSelector('a.b.c').toCssSelector()).toBe '.a.b.c'
+      expect(new ScopeSelector('a b c').toCssSelector()).toBe '.syntax--a .syntax--b .syntax--c'
+      expect(new ScopeSelector('a.b.c').toCssSelector()).toBe '.syntax--a.syntax--b.syntax--c'
       expect(new ScopeSelector('*').toCssSelector()).toBe '*'
-      expect(new ScopeSelector('a - b').toCssSelector()).toBe '.a:not(.b)'
-      expect(new ScopeSelector('a & b').toCssSelector()).toBe '.a .b'
-      expect(new ScopeSelector('a & -b').toCssSelector()).toBe '.a:not(.b)'
-      expect(new ScopeSelector('a | b').toCssSelector()).toBe '.a, .b'
-      expect(new ScopeSelector('a - (b.c d)').toCssSelector()).toBe '.a:not(.b.c .d)'
-      expect(new ScopeSelector('a, b').toCssSelector()).toBe '.a, .b'
-      expect(new ScopeSelector('c++').toCssSelector()).toBe '.c\\+\\+'
+      expect(new ScopeSelector('a - b').toCssSelector()).toBe '.syntax--a:not(.syntax--b)'
+      expect(new ScopeSelector('a & b').toCssSelector()).toBe '.syntax--a .syntax--b'
+      expect(new ScopeSelector('a & -b').toCssSelector()).toBe '.syntax--a:not(.syntax--b)'
+      expect(new ScopeSelector('a | b').toCssSelector()).toBe '.syntax--a, .syntax--b'
+      expect(new ScopeSelector('a - (b.c d)').toCssSelector()).toBe '.syntax--a:not(.syntax--b.syntax--c .syntax--d)'
+      expect(new ScopeSelector('a, b').toCssSelector()).toBe '.syntax--a, .syntax--b'
+      expect(new ScopeSelector('c++').toCssSelector()).toBe '.syntax--c\\+\\+'

--- a/src/scope-selector-matchers.coffee
+++ b/src/scope-selector-matchers.coffee
@@ -6,7 +6,7 @@ class SegmentMatcher
 
   toCssSelector: ->
     @segment.split('.').map((dotFragment) ->
-      '.' + dotFragment.replace(/\+/g, '\\+')
+      '.syntax--' + dotFragment.replace(/\+/g, '\\+')
     ).join('')
 
 class TrueMatcher


### PR DESCRIPTION
This will use the new selector naming standard we're adopting in Atom to prevent ambiguity when the shadow DOM boundary will be removed from `atom-text-editor`.