### PR TITLE
Revert changes to `scopeSelector.toCssSelector()` and add `scopeSelector.toCssSyntaxSelector`

### DIFF
--- a/spec/scope-selector-spec.coffee
+++ b/spec/scope-selector-spec.coffee
@@ -110,3 +110,16 @@ describe "ScopeSelector", ->
       expect(new ScopeSelector('a - (b.c d)').toCssSelector()).toBe '.a:not(.b.c .d)'
       expect(new ScopeSelector('a, b').toCssSelector()).toBe '.a, .b'
       expect(new ScopeSelector('c++').toCssSelector()).toBe '.c\\+\\+'
+
+  describe ".toCssSyntaxSelector()", ->
+    it "converts the TextMate scope selector to a CSS selector prefixing it `syntax--`", ->
+      expect(new ScopeSelector('a b c').toCssSyntaxSelector()).toBe '.syntax--a .syntax--b .syntax--c'
+      expect(new ScopeSelector('a.b.c').toCssSyntaxSelector()).toBe '.syntax--a.syntax--b.syntax--c'
+      expect(new ScopeSelector('*').toCssSyntaxSelector()).toBe '*'
+      expect(new ScopeSelector('a - b').toCssSyntaxSelector()).toBe '.syntax--a:not(.syntax--b)'
+      expect(new ScopeSelector('a & b').toCssSyntaxSelector()).toBe '.syntax--a .syntax--b'
+      expect(new ScopeSelector('a & -b').toCssSyntaxSelector()).toBe '.syntax--a:not(.syntax--b)'
+      expect(new ScopeSelector('a | b').toCssSyntaxSelector()).toBe '.syntax--a, .syntax--b'
+      expect(new ScopeSelector('a - (b.c d)').toCssSyntaxSelector()).toBe '.syntax--a:not(.syntax--b.syntax--c .syntax--d)'
+      expect(new ScopeSelector('a, b').toCssSyntaxSelector()).toBe '.syntax--a, .syntax--b'
+      expect(new ScopeSelector('c++').toCssSyntaxSelector()).toBe '.syntax--c\\+\\+'

--- a/spec/scope-selector-spec.coffee
+++ b/spec/scope-selector-spec.coffee
@@ -100,13 +100,13 @@ describe "ScopeSelector", ->
 
   describe ".toCssSelector()", ->
     it "converts the TextMate scope selector to a CSS selector", ->
-      expect(new ScopeSelector('a b c').toCssSelector()).toBe '.syntax--a .syntax--b .syntax--c'
-      expect(new ScopeSelector('a.b.c').toCssSelector()).toBe '.syntax--a.syntax--b.syntax--c'
+      expect(new ScopeSelector('a b c').toCssSelector()).toBe '.a .b .c'
+      expect(new ScopeSelector('a.b.c').toCssSelector()).toBe '.a.b.c'
       expect(new ScopeSelector('*').toCssSelector()).toBe '*'
-      expect(new ScopeSelector('a - b').toCssSelector()).toBe '.syntax--a:not(.syntax--b)'
-      expect(new ScopeSelector('a & b').toCssSelector()).toBe '.syntax--a .syntax--b'
-      expect(new ScopeSelector('a & -b').toCssSelector()).toBe '.syntax--a:not(.syntax--b)'
-      expect(new ScopeSelector('a | b').toCssSelector()).toBe '.syntax--a, .syntax--b'
-      expect(new ScopeSelector('a - (b.c d)').toCssSelector()).toBe '.syntax--a:not(.syntax--b.syntax--c .syntax--d)'
-      expect(new ScopeSelector('a, b').toCssSelector()).toBe '.syntax--a, .syntax--b'
-      expect(new ScopeSelector('c++').toCssSelector()).toBe '.syntax--c\\+\\+'
+      expect(new ScopeSelector('a - b').toCssSelector()).toBe '.a:not(.b)'
+      expect(new ScopeSelector('a & b').toCssSelector()).toBe '.a .b'
+      expect(new ScopeSelector('a & -b').toCssSelector()).toBe '.a:not(.b)'
+      expect(new ScopeSelector('a | b').toCssSelector()).toBe '.a, .b'
+      expect(new ScopeSelector('a - (b.c d)').toCssSelector()).toBe '.a:not(.b.c .d)'
+      expect(new ScopeSelector('a, b').toCssSelector()).toBe '.a, .b'
+      expect(new ScopeSelector('c++').toCssSelector()).toBe '.c\\+\\+'

--- a/src/scope-selector-matchers.coffee
+++ b/src/scope-selector-matchers.coffee
@@ -11,6 +11,11 @@ class SegmentMatcher
       '.' + dotFragment.replace(/\+/g, '\\+')
     ).join('')
 
+  toCssSyntaxSelector: ->
+    @segment.split('.').map((dotFragment) ->
+      '.syntax--' + dotFragment.replace(/\+/g, '\\+')
+    ).join('')
+
 class TrueMatcher
   constructor: ->
 
@@ -19,6 +24,8 @@ class TrueMatcher
   getPrefix: (scopes) ->
 
   toCssSelector: -> '*'
+
+  toCssSyntaxSelector: -> '*'
 
 class ScopeMatcher
   constructor: (first, others) ->
@@ -45,6 +52,9 @@ class ScopeMatcher
   toCssSelector: ->
     @segments.map((matcher) -> matcher.toCssSelector()).join('')
 
+  toCssSyntaxSelector: ->
+    @segments.map((matcher) -> matcher.toCssSyntaxSelector()).join('')
+
 class GroupMatcher
   constructor: (prefix, selector) ->
     @prefix = prefix?[0]
@@ -55,6 +65,8 @@ class GroupMatcher
   getPrefix: (scopes) -> @prefix if @selector.matches(scopes)
 
   toCssSelector: -> @selector.toCssSelector()
+
+  toCssSyntaxSelector: -> @selector.toCssSyntaxSelector()
 
 class PathMatcher
   constructor: (prefix, first, others) ->
@@ -75,6 +87,9 @@ class PathMatcher
   toCssSelector: ->
     @matchers.map((matcher) -> matcher.toCssSelector()).join(' ')
 
+  toCssSyntaxSelector: ->
+    @matchers.map((matcher) -> matcher.toCssSyntaxSelector()).join(' ')
+
 class OrMatcher
   constructor: (@left, @right) ->
 
@@ -83,6 +98,8 @@ class OrMatcher
   getPrefix: (scopes) -> @left.getPrefix(scopes) or @right.getPrefix(scopes)
 
   toCssSelector: -> "#{@left.toCssSelector()}, #{@right.toCssSelector()}"
+
+  toCssSyntaxSelector: -> "#{@left.toCssSyntaxSelector()}, #{@right.toCssSyntaxSelector()}"
 
 class AndMatcher
   constructor: (@left, @right) ->
@@ -97,6 +114,12 @@ class AndMatcher
     else
       "#{@left.toCssSelector()} #{@right.toCssSelector()}"
 
+  toCssSyntaxSelector: ->
+    if @right instanceof NegateMatcher
+      "#{@left.toCssSyntaxSelector()}#{@right.toCssSyntaxSelector()}"
+    else
+      "#{@left.toCssSyntaxSelector()} #{@right.toCssSyntaxSelector()}"
+
 class NegateMatcher
   constructor: (@matcher) ->
 
@@ -105,6 +128,8 @@ class NegateMatcher
   getPrefix: (scopes) ->
 
   toCssSelector: -> ":not(#{@matcher.toCssSelector()})"
+
+  toCssSyntaxSelector: -> ":not(#{@matcher.toCssSyntaxSelector()})"
 
 class CompositeMatcher
   constructor: (left, operator, right) ->
@@ -118,6 +143,8 @@ class CompositeMatcher
   getPrefix: (scopes) -> @matcher.getPrefix(scopes)
 
   toCssSelector: -> @matcher.toCssSelector()
+
+  toCssSyntaxSelector: -> @matcher.toCssSyntaxSelector()
 
 module.exports = {
   AndMatcher

--- a/src/scope-selector-matchers.coffee
+++ b/src/scope-selector-matchers.coffee
@@ -8,7 +8,7 @@ class SegmentMatcher
 
   toCssSelector: ->
     @segment.split('.').map((dotFragment) ->
-      '.syntax--' + dotFragment.replace(/\+/g, '\\+')
+      '.' + dotFragment.replace(/\+/g, '\\+')
     ).join('')
 
 class TrueMatcher

--- a/src/scope-selector.coffee
+++ b/src/scope-selector.coffee
@@ -29,3 +29,8 @@ class ScopeSelector
   #
   # Returns a {String}.
   toCssSelector: -> @matcher.toCssSelector()
+
+  # Convert this TextMate scope selector to a CSS selector, prefixing scopes with `syntax--`.
+  #
+  # Returns a {String}.
+  toCssSyntaxSelector: -> @matcher.toCssSyntaxSelector()


### PR DESCRIPTION
Reverts atom/first-mate#80 and adds `scopeSelector.toCssSyntaxSelector` to make this change backwards compatible. Users of the first-mate package (such as apm) are currently relying on `toCssSelector` for purposes that are not necessarily related to style sheets (i.e. scoped settings in Atom).