### PR TITLE
Add maxLineLength option to GrammarRegistry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-mate",
-  "version": "6.2.1",
+  "version": "6.2.2-0",
   "description": "TextMate helpers",
   "main": "./lib/first-mate.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-mate",
-  "version": "6.2.2-0",
+  "version": "6.2.2-1",
   "description": "TextMate helpers",
   "main": "./lib/first-mate.js",
   "scripts": {

--- a/spec/fixtures/no-line-length-limit.cson
+++ b/spec/fixtures/no-line-length-limit.cson
@@ -1,0 +1,9 @@
+'name': 'no-line-length-limit'
+'scopeName': 'source.long-lines'
+'limitLineLength': false
+'patterns': [
+  {
+    'match': 'hello'
+    'name': 'prefix.hello'
+  }
+]

--- a/spec/grammar-registry-spec.coffee
+++ b/spec/grammar-registry-spec.coffee
@@ -53,3 +53,11 @@ describe "GrammarRegistry", ->
         '"',
         'this is a long value"}'
       ])
+
+    it "does not apply if the grammar's limitLineLength option is set to false", ->
+      registry = new GrammarRegistry(maxLineLength: 10)
+      loadGrammarSync('no-line-length-limit.cson')
+      grammar = registry.grammarForScopeName('source.long-lines')
+
+      {tokens} = grammar.tokenizeLine("hello goodbye hello goodbye hello")
+      expect(tokens.length).toBe(5)

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -189,6 +189,8 @@ class GrammarRegistry
   createGrammar: (grammarPath, object) ->
     object.maxTokensPerLine ?= @maxTokensPerLine
     object.maxLineLength ?= @maxLineLength
+    if object.limitLineLength is false
+      object.maxLineLength = Infinity
     grammar = new Grammar(this, object)
     grammar.path = grammarPath
     grammar

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -11,6 +11,7 @@ module.exports =
 class GrammarRegistry
   constructor: (options={}) ->
     @maxTokensPerLine = options.maxTokensPerLine ? Infinity
+    @maxLineLength = options.maxLineLength ? Infinity
     @nullGrammar = new NullGrammar(this)
     @clear()
 
@@ -187,6 +188,7 @@ class GrammarRegistry
 
   createGrammar: (grammarPath, object) ->
     object.maxTokensPerLine ?= @maxTokensPerLine
+    object.maxLineLength ?= @maxLineLength
     grammar = new Grammar(this, object)
     grammar.path = grammarPath
     grammar


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/1667#issuecomment-280896197

This will allow us to close all scopes that were opened on a line that exceeded the length limit, similarly to how we handle lines that exceed our token limit.

🍐 'd with @nathansobo

/cc @ThiconZ @50Wliu