### PR TITLE
Add 'alwaysMatchEndPattern' option to end patterns

### DIFF
--- a/spec/fixtures/always-match-end-pattern.cson
+++ b/spec/fixtures/always-match-end-pattern.cson
@@ -1,0 +1,38 @@
+name: "alwaysMatchEndPattern"
+scopeName: "source.always-match-end-pattern"
+patterns: [
+  {
+    begin: 'outer-inner'
+    end: '```'
+    name: 'outer'
+    alwaysMatchEndPattern: true
+    patterns: [
+      {
+        begin: '/\\*'
+        end: '\\*/'
+        name: 'inner'
+      }
+    ]
+  }
+  {
+    begin: 'outer-middle-inner'
+    end: '```'
+    name: 'outer'
+    alwaysMatchEndPattern: true
+    patterns: [
+      {
+        begin: '/\\*'
+        end: '```'
+        name: 'middle'
+        alwaysMatchEndPattern: true
+        patterns: [
+          {
+            begin: '<!--'
+            end: '-->'
+            name: 'inner'
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -295,6 +295,35 @@ describe "Grammar tokenization", ->
           expect(lines[4][2]).toEqual value: "}", scopes: ['source.apply-end-pattern-last', 'normal-env', 'scope']
           expect(lines[4][3]).toEqual value: "excentricSyntax }", scopes: ['source.apply-end-pattern-last', 'normal-env']
 
+      describe "when the alwaysMatchEndPattern flag is set in a pattern", ->
+        beforeEach ->
+          grammar = loadGrammarSync('always-match-end-pattern.cson')
+
+        it "attempts to match that end pattern first even when its included patterns have not finished matching", ->
+          lines = grammar.tokenizeLines """
+            outer-inner
+            /*
+            stuff
+            ```
+          """
+
+          expect(lines[1][0]).toEqual value: '/*', scopes: ['source.always-match-end-pattern', 'outer', 'inner']
+          expect(lines[3][0]).toEqual value: '```', scopes: ['source.always-match-end-pattern', 'outer']
+
+        it "attempts to match the outermost pattern", ->
+          lines = grammar.tokenizeLines """
+            outer-middle-inner
+            /*
+            stuff
+            <!--
+            stuff
+            ```
+          """
+
+          expect(lines[1][0]).toEqual value: '/*', scopes: ['source.always-match-end-pattern', 'outer', 'middle']
+          expect(lines[3][0]).toEqual value: '<!--', scopes: ['source.always-match-end-pattern', 'outer', 'middle', 'inner']
+          expect(lines[5][0]).toEqual value: '```', scopes: ['source.always-match-end-pattern', 'outer']
+
       describe "when the end pattern contains a back reference", ->
         it "constructs the end rule based on its back-references to captures in the begin rule", ->
           grammar = registry.grammarForScopeName('source.ruby')

--- a/src/pattern.coffee
+++ b/src/pattern.coffee
@@ -153,9 +153,10 @@ class Pattern
       while stack.length
         {contentScopeName, scopeName, rule} = stack.pop() if @popRule
         overrideTags.push(@grammar.endIdForScope(contentScopeName)) if contentScopeName
-        overrideTags.push(@grammar.endIdForScope(scopeName)) if scopeName
 
-        break if rule.alwaysMatchEndPattern
+        break if rule.alwaysMatchEndPattern and rule.endPattern is this
+
+        overrideTags.push(@grammar.endIdForScope(scopeName)) if scopeName
 
       tags.unshift(overrideTags...)
     else

--- a/src/rule.coffee
+++ b/src/rule.coffee
@@ -41,8 +41,8 @@ class Rule
   getEndPatternScanner: (ruleStack) ->
     # TODO: Return a cached scanner here if applicable
     patterns = @getIncludedPatterns(ruleStack.shift().rule.grammar)
-    for stack in ruleStack by -1
-      patterns.unshift(stack.rule.endPattern) if stack.rule.endPattern?.alwaysMatchEndPattern
+    for stack in ruleStack
+      patterns.push(stack.rule.endPattern) if stack.rule.endPattern?.alwaysMatchEndPattern
 
     new Scanner(patterns)
 

--- a/src/rule.coffee
+++ b/src/rule.coffee
@@ -39,6 +39,7 @@ class Rule
     scanner
 
   getEndPatternScanner: (ruleStack) ->
+    # TODO: Return a cached scanner here if applicable
     patterns = @getIncludedPatterns(ruleStack.shift().rule.grammar)
     for stack in ruleStack by -1
       patterns.unshift(stack.rule.endPattern) if stack.rule.endPattern?.alwaysMatchEndPattern

--- a/src/scanner.coffee
+++ b/src/scanner.coffee
@@ -59,10 +59,9 @@ class Scanner
   # match - An object returned from a previous call to `findNextMatch`.
   # stack - An array of {Rule} objects.
   # line - The string being scanned.
-  # rule - The rule that matched.
-  # endPatternMatch - true if the rule's end pattern matched.
+  # override - true if an endPattern with `alwaysMatchEndPattern` matched.
   #
   # Returns an array of tokens representing the match.
-  handleMatch: (match, stack, line, rule, endPatternMatch) ->
+  handleMatch: (match, stack, line, override) ->
     pattern = @patterns[match.index]
-    pattern.handleMatch(stack, line, match.captureIndices, rule, endPatternMatch)
+    pattern.handleMatch(stack, line, match.captureIndices, override)


### PR DESCRIPTION
# **🚨 WIP 🚨**

This option, when set to true, will force the end pattern to match, even when it is not the current rule.  This is _incredibly_ useful for grammars that rely on includes, yet do not necessarily need to wait for the include to finish matching before ending the include.  Some examples of such grammars include: language-gfm's code blocks, language-html and language-xml including language-javascript and language-coffee-script, and language-python allowing SQL queries in strings.

TODO:
* [x] Specs
* [ ] Caching for `getEndPatternScanner`
* [ ] A good thorough review :eyes:

Fixes #83
and unblocks a whole lot of issues:
https://github.com/atom/language-php/issues/187
https://github.com/atom/language-shellscript/issues/60
https://github.com/atom/language-gfm/issues/171
https://github.com/atom/language-gfm/issues/21
https://github.com/atom/language-yaml/pull/79
https://github.com/atom/language-html/pull/90
https://github.com/atom/language-python/issues/110
https://github.com/atom/language-python/issues/55
https://github.com/atom/language-python/issues/39
https://github.com/atom/language-python/issues/143
and more...