### PR TITLE
Fix #82: Add back-referencing support to contentName scopes

### DIFF
--- a/spec/fixtures/scope-names-with-placeholders.cson
+++ b/spec/fixtures/scope-names-with-placeholders.cson
@@ -5,4 +5,9 @@ patterns: [
     match: '(a) (b)'
     name: '$1.$2'
   }
+  {
+    begin: '(c) (d)'
+    end: 'e'
+    contentName: '$1.$2'
+  }
 ]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -709,6 +709,16 @@ describe "Grammar tokenization", ->
         expect(tokens[0].value).toEqual "a b"
         expect(tokens[0].scopes).toEqual ["scope-names-with-placeholders", "a.b"]
 
+        {line, tags} = grammar.tokenizeLine("c d - e")
+        tokens = registry.decodeTokens(line, tags)
+        expect(tokens.length).toBe 3
+        expect(tokens[0].value).toEqual "c d"
+        expect(tokens[0].scopes).toEqual ["scope-names-with-placeholders"]
+        expect(tokens[1].value).toEqual " - "
+        expect(tokens[1].scopes).toEqual ["scope-names-with-placeholders", "c.d"]
+        expect(tokens[2].value).toEqual "e"
+        expect(tokens[2].scopes).toEqual ["scope-names-with-placeholders"]
+
   describe "language-specific integration tests", ->
     lines = null
 

--- a/src/pattern.coffee
+++ b/src/pattern.coffee
@@ -159,8 +159,10 @@ class Pattern
       ruleToPush = @pushRule.getRuleToPush(line, captureIndices)
       ruleToPush.anchorPosition = captureIndices[0].end
       {contentScopeName} = ruleToPush
+      if contentScopeName
+        contentScopeName = @resolveScopeName(contentScopeName, line, captureIndices)
+        tags.push(@grammar.startIdForScope(contentScopeName))
       stack.push({rule: ruleToPush, scopeName, contentScopeName, zeroWidthMatch})
-      tags.push(@grammar.startIdForScope(contentScopeName)) if contentScopeName
     else
       {scopeName} = stack.pop() if @popRule
       tags.push(@grammar.endIdForScope(scopeName)) if scopeName


### PR DESCRIPTION
**Take note:** I haven't tested this any further than running `npm test`, as I don't know what the process is for developing node-modules that're bundled with Atom releases. I'm guessing it involves doing full build of Atom...

This PR fixes a bug that currently makes it impossible to reference captures as part of the scope-name (see [`atom/first-mate#82`](https://github.com/atom/first-mate/issues/82)). Which in turn is blocking [`atom/language-gfm#175`](https://github.com/atom/language-gfm/pull/175), as the latter requires the ability to scope captures as part of a rule's `contentName`.