### PR TITLE
Use caret dependency for oniguruma

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "event-kit": "^2.2.0",
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
-    "oniguruma": "6.2.1",
+    "oniguruma": "^6.2.1",
     "season": "^6.0.0",
     "underscore-plus": "^1"
   },


### PR DESCRIPTION
This was changed to an exact dependency in #94. I'm not sure why, other than to update the minimum version, which this also accomplishes. This has the advantage of including future compatible updates to oniguruma, as is the case with all other dependencies of this package.