### PR TITLE
Tokenize empty lines correctly

### DIFF
--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -57,6 +57,13 @@ describe "Grammar tokenization", ->
       expect(tokens[3].value).toBe '!'
       expect(tokens[3].scopes).toEqual ['source.hello', 'suffix.hello', 'emphasis.hello']
 
+  describe '::tokenizeLines(text)', ->
+    describe 'when the text is empty', ->
+      it 'returns a single line with a single token which has the global scope', ->
+        grammar = registry.grammarForScopeName('source.coffee')
+        lines = grammar.tokenizeLines('')
+        expect(lines).toEqual [[{value: '',  scopes: ['source.coffee']}]]
+
   describe "::tokenizeLine(line, ruleStack)", ->
     describe "when the entire line matches a single pattern with no capture groups", ->
       it "returns a single token with the correct scope", ->

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -135,7 +135,7 @@ class Grammar
       previousRuleStackLength = ruleStack.length
       previousPosition = position
 
-      break if position is stringWithNewLine.length
+      break if position > line.length
 
       if tokenCount >= @getMaxTokensPerLine() - 1
         truncatedLine = true


### PR DESCRIPTION
This fixes an issue that appeared in #100 where empty strings were bailed out on too early.

The break condition used to be `break if position is line.length + 1` with a comment suggesting that the 1 is for accounting the line feed character, however the position variable operates between characters, not on them. This means that position of `line.length` is actually the same as cursor being at the end of the line.

cc @50Wliu 