### PR TITLE
Recalculate injections when registry changes

### DIFF
--- a/spec/fixtures/sql-injection.cson
+++ b/spec/fixtures/sql-injection.cson
@@ -1,0 +1,16 @@
+'scopeName': 'source.sql-injection'
+'injections':
+  'source.sql-injection meta.embedded.sql':
+    'patterns': [
+      {
+        'include': 'source.sql'
+      }
+    ]
+'patterns': [
+  {
+    'begin': '"'
+    'end': '"'
+    'name': 'string'
+    'contentName': 'meta.embedded.sql'
+  }
+]

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -37,7 +37,7 @@ class GrammarRegistry
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidAddGrammar: (callback) ->
-    @emitter?.on 'did-add-grammar', callback
+    @emitter.on 'did-add-grammar', callback
 
   # Public: Invoke the given callback when a grammar is updated due to a grammar
   # it depends on being added or removed from the registry.
@@ -47,7 +47,7 @@ class GrammarRegistry
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidUpdateGrammar: (callback) ->
-    @emitter?.on 'did-update-grammar', callback
+    @emitter.on 'did-update-grammar', callback
 
   # Public: Invoke the given callback when a grammar is removed from the registry.
   #
@@ -56,7 +56,7 @@ class GrammarRegistry
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidRemoveGrammar: (callback) ->
-    @emitter?.on 'did-remove-grammar', callback
+    @emitter.on 'did-remove-grammar', callback
 
   ###
   Section: Managing Grammars

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -37,7 +37,7 @@ class GrammarRegistry
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidAddGrammar: (callback) ->
-    @emitter.on 'did-add-grammar', callback
+    @emitter?.on 'did-add-grammar', callback
 
   # Public: Invoke the given callback when a grammar is updated due to a grammar
   # it depends on being added or removed from the registry.
@@ -47,7 +47,7 @@ class GrammarRegistry
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidUpdateGrammar: (callback) ->
-    @emitter.on 'did-update-grammar', callback
+    @emitter?.on 'did-update-grammar', callback
 
   # Public: Invoke the given callback when a grammar is removed from the registry.
   #
@@ -56,7 +56,7 @@ class GrammarRegistry
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidRemoveGrammar: (callback) ->
-    @emitter.on 'did-remove-grammar', callback
+    @emitter?.on 'did-remove-grammar', callback
 
   ###
   Section: Managing Grammars

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -43,10 +43,11 @@ class Grammar
     @fileTypes ?= []
     @includedGrammarScopes = []
 
-    @initialInjections = injections
-    @registry.onDidUpdateGrammar => @recalculateInjections()
-    @registry.onDidAddGrammar => @recalculateInjections()
-    @registry.onDidRemoveGrammar => @recalculateInjections()
+    if injections
+      recalculate = => @injections = new Injections(this, injections)
+      @registry.onDidAddGrammar recalculate
+      @registry.onDidUpdateGrammar recalculate
+      @registry.onDidRemoveGrammar recalculate
 
   ###
   Section: Event Subscription
@@ -269,9 +270,6 @@ class Grammar
       scopes.pop()
 
     scopes
-
-  recalculateInjections: ->
-    @injections = new Injections(this, @initialInjections) if @initialInjections
 
 if Grim.includeDeprecatedAPIs
   EmitterMixin = require('emissary').Emitter

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -44,10 +44,9 @@ class Grammar
     @includedGrammarScopes = []
 
     @initialInjections = injections
-    grammar = this
-    @registry.onDidUpdateGrammar -> grammar.recalculateInjections()
-    @registry.onDidAddGrammar -> grammar.recalculateInjections()
-    @registry.onDidRemoveGrammar -> grammar.recalculateInjections()
+    @registry.onDidUpdateGrammar => @recalculateInjections()
+    @registry.onDidAddGrammar => @recalculateInjections()
+    @registry.onDidRemoveGrammar => @recalculateInjections()
 
   ###
   Section: Event Subscription

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -43,8 +43,11 @@ class Grammar
     @fileTypes ?= []
     @includedGrammarScopes = []
 
-    # Create last since Injections uses APIs from this class
-    @injections = new Injections(this, injections)
+    @initialInjections = injections
+    grammar = this
+    @registry.onDidUpdateGrammar -> grammar.recalculateInjections()
+    @registry.onDidAddGrammar -> grammar.recalculateInjections()
+    @registry.onDidRemoveGrammar -> grammar.recalculateInjections()
 
   ###
   Section: Event Subscription
@@ -267,6 +270,9 @@ class Grammar
       scopes.pop()
 
     scopes
+
+  recalculateInjections: ->
+    @injections = new Injections(this, @initialInjections) if @initialInjections
 
 if Grim.includeDeprecatedAPIs
   EmitterMixin = require('emissary').Emitter

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -27,9 +27,6 @@ class Grammar
     @repository = null
     @initialRule = null
 
-    @rawPatterns = patterns
-    @rawRepository = repository
-
     if injectionSelector?
       @injectionSelector = new ScopeSelector(injectionSelector)
     else
@@ -43,11 +40,11 @@ class Grammar
     @fileTypes ?= []
     @includedGrammarScopes = []
 
-    if injections
-      recalculate = => @injections = new Injections(this, injections)
-      @registry.onDidAddGrammar recalculate
-      @registry.onDidUpdateGrammar recalculate
-      @registry.onDidRemoveGrammar recalculate
+    @rawPatterns = patterns
+    @rawRepository = repository
+    @rawInjections = injections
+
+    @updateRules()
 
   ###
   Section: Event Subscription
@@ -124,11 +121,10 @@ class Grammar
           openScopeTags.push(@registry.startIdForScope(contentScopeName)) if contentScopeName
     else
       openScopeTags = [] if compatibilityMode
-      initialRule = @getInitialRule()
-      {scopeName, contentScopeName} = initialRule
-      ruleStack = [{rule: initialRule, scopeName, contentScopeName}]
-      tags.push(@startIdForScope(initialRule.scopeName)) if scopeName
-      tags.push(@startIdForScope(initialRule.contentScopeName)) if contentScopeName
+      {scopeName, contentScopeName} = @initialRule
+      ruleStack = [{rule: @initialRule, scopeName, contentScopeName}]
+      tags.push(@startIdForScope(@initialRule.scopeName)) if scopeName
+      tags.push(@startIdForScope(@initialRule.contentScopeName)) if contentScopeName
 
     initialRuleStackLength = ruleStack.length
     position = 0
@@ -218,27 +214,28 @@ class Grammar
     @registration?.dispose()
     @registration = null
 
-  clearRules: ->
-    @initialRule = null
-    @repository = null
+  updateRules: ->
+    @initialRule = @createRule({@scopeName, patterns: @rawPatterns})
+    @repository = @createRepository()
+    @injections = new Injections(this, @rawInjections)
 
-  getInitialRule: ->
-    @initialRule ?= @createRule({@scopeName, patterns: @rawPatterns})
+  getInitialRule: -> @initialRule
 
-  getRepository: ->
-    @repository ?= do =>
-      repository = {}
-      for name, data of @rawRepository
-        data = {patterns: [data], tempName: name} if data.begin? or data.match?
-        repository[name] = @createRule(data)
-      repository
+  getRepository: -> @repository
+
+  createRepository: ->
+    repository = {}
+    for name, data of @rawRepository
+      data = {patterns: [data], tempName: name} if data.begin? or data.match?
+      repository[name] = @createRule(data)
+    repository
 
   addIncludedGrammarScope: (scope) ->
     @includedGrammarScopes.push(scope) unless _.include(@includedGrammarScopes, scope)
 
   grammarUpdated: (scopeName) ->
     return false unless _.include(@includedGrammarScopes, scopeName)
-    @clearRules()
+    @updateRules()
     @registry.grammarUpdated(@scopeName)
     @emit 'grammar-updated' if Grim.includeDeprecatedAPIs
     @emitter.emit 'did-update'


### PR DESCRIPTION
https://github.com/atom/language-php/pull/330 revealed that when a grammar is loaded, the injections include only grammars which have been loaded to registry prior to the grammar under question.

This pull request changes the grammar object to re-initialize the injections when the registry add/remove/update events are triggered.