### PR TITLE
Add support for contentRegex

### DIFF
--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -21,7 +21,7 @@ class Grammar
 
   constructor: (@registry, options={}) ->
     {@name, @fileTypes, @scopeName, @foldingStopMarker, @maxTokensPerLine, @maxLineLength} = options
-    {injections, injectionSelector, patterns, repository, firstLineMatch} = options
+    {injections, injectionSelector, patterns, repository, firstLineMatch, contentRegex} = options
 
     @emitter = new Emitter
     @repository = null
@@ -36,6 +36,11 @@ class Grammar
       @firstLineRegex = new OnigRegExp(firstLineMatch)
     else
       @firstLineRegex = null
+      
+    if contentRegex
+      @contentRegex = new OnigRegExp(contentRegex)
+    else
+      @contentRegex = null
 
     @fileTypes ?= []
     @includedGrammarScopes = []


### PR DESCRIPTION
Tree-sitter grammars appear to have a [new property `contentRegex`](https://flight-manual.atom.io/hacking-atom/sections/creating-a-grammar/#language-recognition). Support for this is [already in Atom](https://github.com/atom/atom/blob/699db3092063c5ae56966007694d782b6f8b1a42/src/grammar-registry.js#L228), all that's required for TextMate to benefit from it is to add in when constructing the grammar.

In particular, this will help differentiate similar grammars such as LaTeX & LaTeX Beamer. In this case, both share the same file extension, and both can potentially not match the first line regex. It is difficult / impossible to influence the score in a way that works in all cases.

With the change, the solution is just add `contentRegex` to Beamer. If it matches, it gets a edge over LaTeX. If it fails, it gets a penalty and LaTeX consistently gets applied.

Alternatively, Atom could be changed to give a penalty when the `firstLineMatch` fails, but this may have unwanted consequences.