### PR TITLE
package.json: rename prepublish script to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/first-mate.js",
   "scripts": {
     "test": "grunt test",
-    "prepublish": "grunt prepublish",
+    "prepare": "grunt prepublish",
     "benchmark": "node_modules/.bin/coffee benchmark/benchmark.coffee"
   },
   "repository": {


### PR DESCRIPTION
### Brief summary

The "prepublish" script is deprecated. In npm 7, it doesn't run
before publishing, only on local `npm install` or `npm ci`.

The new "prepare" script does what "prepublish" used to do.

### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Should prevent things like https://github.com/atom/first-mate/issues/121 when publishing with npm 7. 

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In `package.json`, rename the `prepublish` script to `prepare`.

(The `prepublish` script name has been deprecated for a long time), to `prepare`. `prepare` is the new script name that does what `prepublish` used to do. For some reason, the `npm` 7 authors decided a good way to move forward with deprecating/disabling the `prepublish` script was to make it still run on local `npm install` or `npm ci`, but not during `npm publish`.

By switching to `prepare`, we preserve the old behavior of running on local `npm install`, local `npm ci`, AND on `npm publish`.

See:
- https://docs.npmjs.com/cli/v6/using-npm/scripts
- https://docs.npmjs.com/cli/v7/using-npm/scripts

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

We could rename this script to `prepublishOnly`...

But that doesn't run when specifying this package as a git URL in `package.json`, making it slightly harder to test draft changes to this package locally, that is before publishing the changes you want to test to the npm package registry... With `prepare` you can push a draft of this package to your fork on GitHub and test the package that way.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

I can't verify that the `publish` change actually works, but it says it will in the documentation I linked. (https://docs.npmjs.com/cli/v7/using-npm/scripts).

I can confirm that renaming the script to `prepare` makes it so this package can be downloaded from a git URL and still function properly (still build the `lib/` folder during install). (I tested by adding my personal GitHub fork in `package.json` of a dummy project and doing `npm install` and checking if the `lib/` folder existed. It did with my changes.) (This package would not work from a git URL if using the `prepublishOnly` script name.)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fix issue when publishing package with npm 7